### PR TITLE
Handle UUID persistency and new widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-02-26
+## [0.1.0] - 2026-02-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-10
+
+### Added
+
+- implemented timepicker (spinner) widget [#35](https://github.com/grp-bork/TRECollect/issues/35)
+
+### Changed
+
+- fix the persistency of UUID [#10](https://github.com/grp-bork/TRECollect/issues/10)
+- photo widget allows selecting existing photo and preview selected photo [#34](https://github.com/grp-bork/TRECollect/issues/34)
+- local files duplication eliminated [#36](https://github.com/grp-bork/TRECollect/issues/36)
+
 ## [0.1.0] - 2026-02-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ TRECollect is an Android application for collecting and managing field sampling 
   - Room database for local persistence
   - XML-based form data storage
   - Team/subteam-based folder organization:
-    - Local: `TREC_logsheets/{team}/{subteam}/{ongoing,finished,deleted}/`
+    - Local: `TRECollect_logsheets/{team}/{subteam}/{ongoing,finished,deleted}/`
     - ownCloud: `{UUID}/{team}/{subteam}/{siteName}/`
 
 ## Requirements
@@ -91,7 +91,7 @@ TRECollect is an Android application for collecting and managing field sampling 
    - This determines which forms are available and the folder structure
 
 2. **Select Output Folder**: Choose where submissions will be stored
-   - The app will create the folder structure: `TREC_logsheets/{team}/{subteam}/`
+   - The app will create the folder structure: `TRECollect_logsheets/{team}/{subteam}/`
 
 3. **Optional - ownCloud (uploads and logsheet downloads):** Credentials are **not** in the repo. Copy `local.properties.example` to `local.properties` and set:
    - `owncloud.url`: Your ownCloud WebDAV base URL (e.g. `https://oc.example.com/public.php/webdav/`)
@@ -184,7 +184,7 @@ app/
 
 **Local Storage:**
 ```
-TREC_logsheets/
+TRECollect_logsheets/
 ├── LSI/
 │   ├── Soil/
 │   │   ├── ongoing/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            // BuildConfig.DEBUG = true → app uses fixed "dev-debug" UUID
+        }
         release {
             if (project.findProperty("RELEASE_STORE_FILE") != null) {
                 signingConfig signingConfigs.release

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,9 +28,9 @@ android {
         minSdk = 24
         targetSdk = 34
         // CI/release: set via -PVERSION_CODE and -PVERSION_NAME (e.g. from release tag v1.2.3).
-        // Debug/local: versionName "0.0.0" so Settings shows "v0.0.0"; versionCode must be >= 1.
+        // Debug/local: versionName "dev" so Settings shows "vdev"; versionCode must be >= 1.
         versionCode project.findProperty("VERSION_CODE") != null ? Integer.parseInt(project.findProperty("VERSION_CODE").toString()) : 1
-        versionName project.findProperty("VERSION_NAME") ?: "0.0.0"
+        versionName project.findProperty("VERSION_NAME")?.toString()?.trim() ?: "dev"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/trec/trecollect/ui/AutomaticUploadCheckboxTest.kt
+++ b/app/src/androidTest/java/com/trec/trecollect/ui/AutomaticUploadCheckboxTest.kt
@@ -3,6 +3,7 @@ package com.trec.trecollect.ui
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.trec.trecollect.MainActivity
 import com.trec.trecollect.data.AppDatabase
 import com.trec.trecollect.data.SamplingSite
@@ -74,6 +75,7 @@ class AutomaticUploadCheckboxTest {
         val start = System.currentTimeMillis()
         var listWithUploaded: List<SamplingSite>? = null
         while (System.currentTimeMillis() - start < timeoutMs) {
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
             val list = viewModel.finishedSites.first()
             if (list.any { it.name == siteName && it.uploadStatus == UploadStatus.UPLOADED }) {
                 listWithUploaded = list

--- a/app/src/main/java/com/trec/trecollect/MainActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.IntentCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -86,7 +87,7 @@ class MainActivity : AppCompatActivity() {
      * the upload in our ViewModel so the checkbox updates when it completes.
      */
     private fun handleSiteToUploadFromIntent(intent: Intent?) {
-        val site = intent?.getParcelableExtra<SamplingSite>(EXTRA_SITE_TO_UPLOAD) ?: return
+        val site = intent?.let { IntentCompat.getParcelableExtra(it, EXTRA_SITE_TO_UPLOAD, SamplingSite::class.java) } ?: return
         intent.removeExtra(EXTRA_SITE_TO_UPLOAD)
         viewModel.startAutomaticUploadForSite(site)
     }

--- a/app/src/main/java/com/trec/trecollect/MainActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/MainActivity.kt
@@ -471,6 +471,13 @@ class MainActivity : AppCompatActivity() {
                     return@launch
                 }
                 
+                // Create ownCloud folder only after the user has selected an output folder.
+                // That way we've already run ensureUuidFileInOutputFolder (write or read UUID),
+                // so the app UUID is stable and we don't create a folder that will never be used.
+                if (settingsPreferences.getFolderUri().isEmpty()) {
+                    return@launch
+                }
+                
                 val appUuid = settingsPreferences.getAppUuid()
                 AppLogger.d("MainActivity", "Retrying ownCloud folder creation for UUID: $appUuid")
                 val ownCloudManager = OwnCloudManager(this@MainActivity)

--- a/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
@@ -38,7 +38,7 @@ class FolderStructureHelper(private val context: Context) {
         // 1) Try listFiles() first (often more up-to-date than findFile after a create)
         try {
             val files = parent.listFiles()
-            val folder = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+            val folder = files.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
             if (folder != null) return folder
         } catch (e: Exception) {
             android.util.Log.w("FolderStructureHelper", "Error listing files in ${parent.name}: ${e.message}")
@@ -53,13 +53,13 @@ class FolderStructureHelper(private val context: Context) {
         if (created.name != folderName) {
             try {
                 val files = parent.listFiles()
-                val exact = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+                val exact = files.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
                 if (exact != null) return exact
             } catch (_: Exception) { }
         }
         try {
             val files = parent.listFiles()
-            val existing = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+            val existing = files.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
             if (existing != null) return existing
         } catch (_: Exception) { }
         return created

--- a/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
@@ -103,24 +103,22 @@ class FolderStructureHelper(private val context: Context) {
 
     /**
      * Ensures the UUID file exists in the root of the output folder (TRECollect_logsheets).
-     * If the file already exists, reads the UUID from it and sets it as the app UUID (does not overwrite).
-     * If the file does not exist, writes the current app UUID to a new file.
-     * Call this when the output folder is selected (e.g. after user picks a folder in Settings).
+     * If the file already exists (release only), reads the UUID and sets it in prefs.
+     * If the file does not exist, writes the current app UUID (getAppUuid()) to a new file.
      */
     fun ensureUuidFileInOutputFolder(trecFolder: DocumentFile, settingsPreferences: SettingsPreferences) {
         if (!trecFolder.exists() || !trecFolder.canWrite()) return
         val existingFile = trecFolder.findFile(UUID_FILENAME)
         if (existingFile != null && existingFile.exists() && existingFile.canRead()) {
-            try {
-                context.contentResolver.openInputStream(existingFile.uri)?.use { input ->
-                    val uuid = input.bufferedReader().readText().trim()
-                    if (uuid.isNotEmpty()) {
-                        settingsPreferences.setAppUuid(uuid)
-                        android.util.Log.i("FolderStructureHelper", "Using UUID from output folder: $uuid")
+            if (!settingsPreferences.isDevBuild()) {
+                try {
+                    context.contentResolver.openInputStream(existingFile.uri)?.use { input ->
+                        val uuid = input.bufferedReader().readText().trim()
+                        if (uuid.isNotEmpty()) settingsPreferences.setAppUuid(uuid)
                     }
+                } catch (e: Exception) {
+                    android.util.Log.w("FolderStructureHelper", "Could not read UUID file: ${e.message}")
                 }
-            } catch (e: Exception) {
-                android.util.Log.w("FolderStructureHelper", "Could not read UUID file: ${e.message}")
             }
             return
         }
@@ -129,7 +127,6 @@ class FolderStructureHelper(private val context: Context) {
             val file = trecFolder.createFile("text/plain", UUID_FILENAME)
             if (file != null && file.exists()) {
                 context.contentResolver.openOutputStream(file.uri)?.use { it.write(uuid.toByteArray()) }
-                android.util.Log.i("FolderStructureHelper", "Wrote UUID file to output folder: $uuid")
             }
         } catch (e: Exception) {
             android.util.Log.w("FolderStructureHelper", "Could not write UUID file: ${e.message}")

--- a/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
@@ -7,7 +7,7 @@ import androidx.documentfile.provider.DocumentFile
 
 class FolderStructureHelper(private val context: Context) {
     companion object {
-        const val PARENT_FOLDER_NAME = "TREC_logsheets"
+        const val PARENT_FOLDER_NAME = "TRECollect_logsheets"
         const val ONGOING_FOLDER = "ongoing"
         const val FINISHED_FOLDER = "finished"
         const val DELETED_FOLDER = "deleted"
@@ -30,7 +30,7 @@ class FolderStructureHelper(private val context: Context) {
     }
 
     /**
-     * Gets the TREC_logsheets folder URI from settings
+     * Gets the TRECollect_logsheets folder URI from settings
      */
     fun getTrecLogsheetsFolderUri(settingsPreferences: SettingsPreferences): Uri? {
         val uriString = settingsPreferences.getFolderUri()
@@ -46,33 +46,33 @@ class FolderStructureHelper(private val context: Context) {
     }
     
     /**
-     * Gets the DocumentFile for the TREC_logsheets folder
-     * The stored URI should point directly to TREC_logsheets folder
-     * If the URI points to a parent folder, it will look for TREC_logsheets inside it
+     * Gets the DocumentFile for the TRECollect_logsheets folder
+     * The stored URI should point directly to TRECollect_logsheets folder
+     * If the URI points to a parent folder, it will look for TRECollect_logsheets inside it
      */
     fun getTrecLogsheetsFolder(settingsPreferences: SettingsPreferences): DocumentFile? {
         val uri = getTrecLogsheetsFolderUri(settingsPreferences) ?: return null
         try {
-            // The URI stored should be a tree URI pointing to TREC_logsheets
+            // The URI stored should be a tree URI pointing to TRECollect_logsheets
             val documentFile = DocumentFile.fromTreeUri(context, uri)
             if (documentFile == null) {
                 android.util.Log.e("FolderStructureHelper", "DocumentFile.fromTreeUri returned null for URI: $uri")
                 return null
             }
             
-            // Verify it's actually the TREC_logsheets folder by checking the name
+            // Verify it's actually the TRECollect_logsheets folder by checking the name
             val folderName = documentFile.name
             android.util.Log.d("FolderStructureHelper", "Retrieved folder name: '$folderName', expected: '$PARENT_FOLDER_NAME'")
             
             if (folderName != null && folderName == PARENT_FOLDER_NAME) {
-                // This is the TREC_logsheets folder - return it
+                // This is the TRECollect_logsheets folder - return it
                 return documentFile
             }
             
             // If name doesn't match, the URI might point to the parent folder
-            // Try to find TREC_logsheets inside it (use both findFile and listFiles for reliability)
+            // Try to find TRECollect_logsheets inside it (use both findFile and listFiles for reliability)
             if (folderName != null) {
-                android.util.Log.w("FolderStructureHelper", "URI points to '$folderName', not '$PARENT_FOLDER_NAME'. Looking for TREC_logsheets inside...")
+                android.util.Log.w("FolderStructureHelper", "URI points to '$folderName', not '$PARENT_FOLDER_NAME'. Looking for TRECollect_logsheets inside...")
                 var trecFolder = documentFile.findFile(PARENT_FOLDER_NAME)
                 if (trecFolder == null || !trecFolder.exists()) {
                     // Also check by listing files (fallback in case findFile() doesn't work reliably)
@@ -80,27 +80,27 @@ class FolderStructureHelper(private val context: Context) {
                         val files = documentFile.listFiles()
                         trecFolder = files.firstOrNull { it.name == PARENT_FOLDER_NAME && it.isDirectory && it.exists() }
                     } catch (e: Exception) {
-                        android.util.Log.w("FolderStructureHelper", "Error listing files to find TREC_logsheets: ${e.message}")
+                        android.util.Log.w("FolderStructureHelper", "Error listing files to find TRECollect_logsheets: ${e.message}")
                     }
                 }
                 if (trecFolder != null && trecFolder.exists()) {
-                    android.util.Log.d("FolderStructureHelper", "Found TREC_logsheets inside parent folder")
+                    android.util.Log.d("FolderStructureHelper", "Found TRECollect_logsheets inside parent folder")
                     return trecFolder
                 }
             }
             
-            // If we can't find TREC_logsheets, don't return the wrong folder
+            // If we can't find TRECollect_logsheets, don't return the wrong folder
             // This prevents creating team folders at the wrong level
-            android.util.Log.e("FolderStructureHelper", "Could not find TREC_logsheets folder. URI points to '$folderName' but TREC_logsheets not found inside it.")
+            android.util.Log.e("FolderStructureHelper", "Could not find TRECollect_logsheets folder. URI points to '$folderName' but TRECollect_logsheets not found inside it.")
             return null
         } catch (e: Exception) {
-            android.util.Log.e("FolderStructureHelper", "Error getting TREC_logsheets folder: ${e.message}", e)
+            android.util.Log.e("FolderStructureHelper", "Error getting TRECollect_logsheets folder: ${e.message}", e)
             return null
         }
     }
     
     /**
-     * Gets the team folder inside TREC_logsheets
+     * Gets the team folder inside TRECollect_logsheets
      * Safely handles existing folders to avoid creating duplicates
      */
     private fun getTeamFolder(settingsPreferences: SettingsPreferences): DocumentFile? {
@@ -112,7 +112,7 @@ class FolderStructureHelper(private val context: Context) {
     
     /**
      * Gets the subteam folder for the current team/subteam
-     * All teams now use the same structure: TREC_logsheets/{team}/{subteam}/
+     * All teams now use the same structure: TRECollect_logsheets/{team}/{subteam}/
      * Safely handles existing folders to avoid creating duplicates
      */
     private fun getSubteamFolder(settingsPreferences: SettingsPreferences): DocumentFile? {
@@ -163,7 +163,7 @@ class FolderStructureHelper(private val context: Context) {
 
     /**
      * Ensures the folder structure exists, creating it only if it doesn't exist.
-     * Structure: baseFolder/TREC_logsheets/{team}/{subteam}/{ongoing, finished, deleted}.
+     * Structure: baseFolder/TRECollect_logsheets/{team}/{subteam}/{ongoing, finished, deleted}.
      * Called when the user selects a base folder (e.g. in Settings); [ensureSubfoldersExist] is used to ensure ongoing/finished/deleted exist for the current team/subteam.
      */
     fun ensureFolderStructure(baseUri: Uri, settingsPreferences: SettingsPreferences): DocumentFile? {
@@ -192,16 +192,16 @@ class FolderStructureHelper(private val context: Context) {
             return null
         }
 
-        android.util.Log.i("FolderStructureHelper", "TREC_logsheets folder ready: ${trecFolder.uri}")
+        android.util.Log.i("FolderStructureHelper", "TRECollect_logsheets folder ready: ${trecFolder.uri}")
 
         val team = settingsPreferences.getSamplingTeam()
         val subteam = settingsPreferences.getSamplingSubteam()
         if (team.isEmpty()) {
-            android.util.Log.i("FolderStructureHelper", "Team not set - TREC_logsheets created, team/subteam later")
+            android.util.Log.i("FolderStructureHelper", "Team not set - TRECollect_logsheets created, team/subteam later")
             return trecFolder
         }
         if (subteam.isEmpty()) {
-            android.util.Log.i("FolderStructureHelper", "Subteam not set - TREC_logsheets created, team/subteam later")
+            android.util.Log.i("FolderStructureHelper", "Subteam not set - TRECollect_logsheets created, team/subteam later")
             return trecFolder
         }
 
@@ -220,7 +220,7 @@ class FolderStructureHelper(private val context: Context) {
     }
 
     /**
-     * Ensures the TREC_logsheets subfolders (ongoing, finished, deleted) exist for the current team/subteam.
+     * Ensures the TRECollect_logsheets subfolders (ongoing, finished, deleted) exist for the current team/subteam.
      * Called when team/subteam are already set and we need to ensure the three subfolders exist (e.g. after settings change or before save).
      */
     fun ensureSubfoldersExist(settingsPreferences: SettingsPreferences): Boolean {

--- a/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
+import java.util.concurrent.ConcurrentHashMap
 
 class FolderStructureHelper(private val context: Context) {
     companion object {
@@ -13,22 +14,55 @@ class FolderStructureHelper(private val context: Context) {
         const val DELETED_FOLDER = "deleted"
         /** Filename for the UUID file stored in the root of the output folder. */
         const val UUID_FILENAME = "app_uuid.txt"
+        
+        /** Locks per (parentUri, folderName) so concurrent callers don't both create the same folder. */
+        private val folderLocks = ConcurrentHashMap<String, Any>()
+        private fun lockFor(parentUri: Uri, folderName: String): Any =
+            folderLocks.getOrPut("${parentUri}_$folderName") { Any() }
     }
 
     /**
-     * Finds an existing child folder by name or creates it. Uses findFile first, then listFiles as fallback, then createDirectory.
+     * Finds an existing child folder by name or creates it. Uses a per-folder lock so that
+     * concurrent callers (e.g. Settings + ViewModel) don't both create the same folder.
+     * After createDirectory, if the provider returned a duplicate (e.g. "ongoing (1)"), we
+     * re-query and return the folder with the exact name so callers always get the canonical folder.
      */
     private fun findOrCreateChildFolder(parent: DocumentFile, folderName: String): DocumentFile? {
-        var folder = parent.findFile(folderName)
-        if (folder != null && folder.exists()) return folder
+        val lock = lockFor(parent.uri, folderName)
+        return synchronized(lock) {
+            findOrCreateChildFolderLocked(parent, folderName)
+        }
+    }
+    
+    private fun findOrCreateChildFolderLocked(parent: DocumentFile, folderName: String): DocumentFile? {
+        // 1) Try listFiles() first (often more up-to-date than findFile after a create)
         try {
             val files = parent.listFiles()
-            folder = files.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+            val folder = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
             if (folder != null) return folder
         } catch (e: Exception) {
             android.util.Log.w("FolderStructureHelper", "Error listing files in ${parent.name}: ${e.message}")
         }
-        return parent.createDirectory(folderName)
+        // 2) Try findFile
+        var folder = parent.findFile(folderName)
+        if (folder != null && folder.exists()) return folder
+        // 3) Create
+        val created = parent.createDirectory(folderName) ?: return null
+        // 4) If provider created a duplicate (e.g. "ongoing (1)" because "ongoing" already existed),
+        //    find and return the folder with the exact name so we never return the (1) variant
+        if (created.name != folderName) {
+            try {
+                val files = parent.listFiles()
+                val exact = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+                if (exact != null) return exact
+            } catch (_: Exception) { }
+        }
+        try {
+            val files = parent.listFiles()
+            val existing = files?.firstOrNull { it.name == folderName && it.isDirectory && it.exists() }
+            if (existing != null) return existing
+        } catch (_: Exception) { }
+        return created
     }
 
     /**
@@ -254,11 +288,25 @@ class FolderStructureHelper(private val context: Context) {
     }
 
     /**
-     * Ensures the TRECollect_logsheets subfolders (ongoing, finished, deleted) exist for the current team/subteam.
-     * Called when team/subteam are already set and we need to ensure the three subfolders exist (e.g. after settings change or before save).
+     * Ensures the TRECollect_logsheets subfolders (team/subteam/ongoing/finished/deleted) exist.
+     * Uses the stored folder URI. Use when folder is already saved (e.g. after team/subteam change).
      */
     fun ensureSubfoldersExist(settingsPreferences: SettingsPreferences): Boolean {
         val subteamFolder = getSubteamFolder(settingsPreferences) ?: return false
+        return ensureSubfoldersInSubteamFolder(subteamFolder)
+    }
+
+    /**
+     * Ensures team/subteam/ongoing/finished/deleted exist under the given TRECollect_logsheets folder.
+     * Use this when you have the trecFolder directly (e.g. right after creating it) so the folder
+     * URI does not need to be saved yet. Avoids creating team/subteam twice.
+     */
+    fun ensureSubfoldersExist(trecFolder: DocumentFile, settingsPreferences: SettingsPreferences): Boolean {
+        val team = settingsPreferences.getSamplingTeam()
+        val subteam = settingsPreferences.getSamplingSubteam()
+        if (team.isEmpty() || subteam.isEmpty()) return true
+        val teamFolder = findOrCreateChildFolder(trecFolder, team) ?: return false
+        val subteamFolder = findOrCreateChildFolder(teamFolder, subteam) ?: return false
         return ensureSubfoldersInSubteamFolder(subteamFolder)
     }
 }

--- a/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FolderStructureHelper.kt
@@ -11,6 +11,8 @@ class FolderStructureHelper(private val context: Context) {
         const val ONGOING_FOLDER = "ongoing"
         const val FINISHED_FOLDER = "finished"
         const val DELETED_FOLDER = "deleted"
+        /** Filename for the UUID file stored in the root of the output folder. */
+        const val UUID_FILENAME = "app_uuid.txt"
     }
 
     /**
@@ -96,6 +98,41 @@ class FolderStructureHelper(private val context: Context) {
         } catch (e: Exception) {
             android.util.Log.e("FolderStructureHelper", "Error getting TRECollect_logsheets folder: ${e.message}", e)
             return null
+        }
+    }
+
+    /**
+     * Ensures the UUID file exists in the root of the output folder (TRECollect_logsheets).
+     * If the file already exists, reads the UUID from it and sets it as the app UUID (does not overwrite).
+     * If the file does not exist, writes the current app UUID to a new file.
+     * Call this when the output folder is selected (e.g. after user picks a folder in Settings).
+     */
+    fun ensureUuidFileInOutputFolder(trecFolder: DocumentFile, settingsPreferences: SettingsPreferences) {
+        if (!trecFolder.exists() || !trecFolder.canWrite()) return
+        val existingFile = trecFolder.findFile(UUID_FILENAME)
+        if (existingFile != null && existingFile.exists() && existingFile.canRead()) {
+            try {
+                context.contentResolver.openInputStream(existingFile.uri)?.use { input ->
+                    val uuid = input.bufferedReader().readText().trim()
+                    if (uuid.isNotEmpty()) {
+                        settingsPreferences.setAppUuid(uuid)
+                        android.util.Log.i("FolderStructureHelper", "Using UUID from output folder: $uuid")
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("FolderStructureHelper", "Could not read UUID file: ${e.message}")
+            }
+            return
+        }
+        val uuid = settingsPreferences.getAppUuid()
+        try {
+            val file = trecFolder.createFile("text/plain", UUID_FILENAME)
+            if (file != null && file.exists()) {
+                context.contentResolver.openOutputStream(file.uri)?.use { it.write(uuid.toByteArray()) }
+                android.util.Log.i("FolderStructureHelper", "Wrote UUID file to output folder: $uuid")
+            }
+        } catch (e: Exception) {
+            android.util.Log.w("FolderStructureHelper", "Could not write UUID file: ${e.message}")
         }
     }
     

--- a/app/src/main/java/com/trec/trecollect/data/FormConfig.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FormConfig.kt
@@ -37,6 +37,7 @@ data class FormFieldConfig(
         TEXTAREA,
         DATE,
         TIME,
+        TIMEPICKER, // Spinner for hours, minutes, seconds (0–60), stored as HH:MM:SS
         SELECT,
         MULTISELECT,
         SELECT_IMAGE, // Single select with images
@@ -616,6 +617,7 @@ object FormConfigLoader {
                     "textarea" -> FormFieldConfig.FieldType.TEXTAREA
                     "date" -> FormFieldConfig.FieldType.DATE
                     "time" -> FormFieldConfig.FieldType.TIME
+                    "timepicker" -> FormFieldConfig.FieldType.TIMEPICKER
                     "select" -> FormFieldConfig.FieldType.SELECT
                     "multiselect" -> FormFieldConfig.FieldType.MULTISELECT
                     "select_image" -> FormFieldConfig.FieldType.SELECT_IMAGE
@@ -710,6 +712,7 @@ object FormConfigLoader {
                         FormFieldConfig.FieldType.MULTISELECT_IMAGE,
                         FormFieldConfig.FieldType.DATE,
                         FormFieldConfig.FieldType.TIME,
+                        FormFieldConfig.FieldType.TIMEPICKER,
                         FormFieldConfig.FieldType.CHECKBOX -> defaultValueString.takeIf { it.isNotEmpty() }
                         else -> null
                     }

--- a/app/src/main/java/com/trec/trecollect/data/FormData.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FormData.kt
@@ -14,7 +14,7 @@ data class FormFieldValue(
     val values: List<String>? = null, // For multiselect
     val gpsLatitude: Double? = null, // For GPS
     val gpsLongitude: Double? = null, // For GPS
-    val photoFileName: String? = null, // For photo (just filename, not full path)
+    val photoFileName: String? = null, // For photo: filename in app's photos dir
     val tableData: Map<String, Map<String, String>>? = null, // For table: Map<rowName, Map<columnName, value>>
     val dynamicData: List<Map<String, FormFieldValue>>? = null // For dynamic: List of instances, each instance is Map<subFieldId, FormFieldValue>
 )

--- a/app/src/main/java/com/trec/trecollect/data/FormData.kt
+++ b/app/src/main/java/com/trec/trecollect/data/FormData.kt
@@ -17,7 +17,18 @@ data class FormFieldValue(
     val photoFileName: String? = null, // For photo: filename in app's photos dir
     val tableData: Map<String, Map<String, String>>? = null, // For table: Map<rowName, Map<columnName, value>>
     val dynamicData: List<Map<String, FormFieldValue>>? = null // For dynamic: List of instances, each instance is Map<subFieldId, FormFieldValue>
-)
+) {
+    /** True if this field has any content that should be serialized to XML. Used to skip empty fields. */
+    fun hasSerializableContent(): Boolean {
+        if (!value.isNullOrBlank()) return true
+        if (!values.isNullOrEmpty()) return true
+        if (gpsLatitude != null && gpsLongitude != null) return true
+        if (!photoFileName.isNullOrBlank()) return true
+        if (!tableData.isNullOrEmpty()) return true
+        if (!dynamicData.isNullOrEmpty()) return true
+        return false
+    }
+}
 
 /**
  * Represents a complete form submission or draft
@@ -54,6 +65,7 @@ data class FormData(
         
         serializer.startTag(null, "fields")
         for (fieldValue in fieldValues) {
+            if (!fieldValue.hasSerializableContent()) continue
             serializer.startTag(null, "field")
             serializer.attribute(null, "id", fieldValue.fieldId)
             
@@ -70,8 +82,8 @@ data class FormData(
                 serializer.attribute(null, "gpsLongitude", fieldValue.gpsLongitude.toString())
             }
             
-            if (fieldValue.photoFileName != null) {
-                serializer.attribute(null, "photoFileName", fieldValue.photoFileName)
+            fieldValue.photoFileName?.takeIf { it.isNotBlank() }?.let {
+                serializer.attribute(null, "photoFileName", it)
             }
             
             if (fieldValue.tableData != null && fieldValue.tableData.isNotEmpty()) {
@@ -108,8 +120,8 @@ data class FormData(
                             serializer.attribute(null, "gpsLatitude", subFieldValue.gpsLatitude.toString())
                             serializer.attribute(null, "gpsLongitude", subFieldValue.gpsLongitude.toString())
                         }
-                        if (subFieldValue.photoFileName != null) {
-                            serializer.attribute(null, "photoFileName", subFieldValue.photoFileName)
+                        subFieldValue.photoFileName?.takeIf { it.isNotBlank() }?.let {
+                            serializer.attribute(null, "photoFileName", it)
                         }
                         if (subFieldValue.tableData != null && subFieldValue.tableData.isNotEmpty()) {
                             val tableJson = org.json.JSONObject()
@@ -225,7 +237,7 @@ data class FormData(
                                         currentValues = valuesStr?.split(",")?.map { it.trim() }
                                         currentGpsLat = parser.getAttributeValue(null, "gpsLatitude")?.toDoubleOrNull()
                                         currentGpsLon = parser.getAttributeValue(null, "gpsLongitude")?.toDoubleOrNull()
-                                        currentPhotoFileName = parser.getAttributeValue(null, "photoFileName")
+                                        currentPhotoFileName = parser.getAttributeValue(null, "photoFileName")?.takeIf { it.isNotBlank() }
                                         val tableDataStr = parser.getAttributeValue(null, "tableData")
                                         currentTableData = if (tableDataStr != null) {
                                             try {
@@ -267,7 +279,7 @@ data class FormData(
                                     currentSubFieldValues = valuesStr?.split(",")?.map { it.trim() }
                                     currentSubFieldGpsLat = parser.getAttributeValue(null, "gpsLatitude")?.toDoubleOrNull()
                                     currentSubFieldGpsLon = parser.getAttributeValue(null, "gpsLongitude")?.toDoubleOrNull()
-                                    currentSubFieldPhotoFileName = parser.getAttributeValue(null, "photoFileName")
+                                    currentSubFieldPhotoFileName = parser.getAttributeValue(null, "photoFileName")?.takeIf { it.isNotBlank() }
                                     val tableDataStr = parser.getAttributeValue(null, "tableData")
                                     currentSubFieldTableData = if (tableDataStr != null) {
                                         try {

--- a/app/src/main/java/com/trec/trecollect/data/SettingsPreferences.kt
+++ b/app/src/main/java/com/trec/trecollect/data/SettingsPreferences.kt
@@ -89,6 +89,13 @@ class SettingsPreferences(context: Context) {
         }
         return uuid
     }
+
+    /**
+     * Sets the app UUID (e.g. when read from the UUID file in the output folder).
+     */
+    fun setAppUuid(uuid: String) {
+        prefs.edit { putString(KEY_APP_UUID, uuid) }
+    }
     
     /**
      * Checks if ownCloud folder has been verified/created

--- a/app/src/main/java/com/trec/trecollect/data/SettingsPreferences.kt
+++ b/app/src/main/java/com/trec/trecollect/data/SettingsPreferences.kt
@@ -3,8 +3,9 @@ package com.trec.trecollect.data
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.trec.trecollect.BuildConfig
 
-class SettingsPreferences(context: Context) {
+class SettingsPreferences(context: Context, private val isDevBuildOverride: (() -> Boolean)? = null) {
     private val prefs: SharedPreferences = context.getSharedPreferences(
         PREFS_NAME,
         Context.MODE_PRIVATE
@@ -22,8 +23,16 @@ class SettingsPreferences(context: Context) {
         private const val KEY_LOGSHEETS_DOWNLOADED = "logsheets_downloaded"
         
         const val DEFAULT_MAP_EXPIRY_DAYS = 30L // Default: 30 days
+        
+        /** Fixed identifier for debug builds so all dev data goes to one ownCloud folder. */
+        private val DEV_BUILD_UUID: String = "dev-debug"
     }
     
+    /** True for debug builds; use fixed "dev-debug" UUID. Release uses generated/stored UUID. */
+    fun isDevBuild(): Boolean {
+        isDevBuildOverride?.let { return it() }
+        return BuildConfig.DEBUG
+    }
     fun getSubmissionPath(): String {
         return prefs.getString(KEY_SUBMISSION_PATH, "") ?: ""
     }
@@ -79,9 +88,11 @@ class SettingsPreferences(context: Context) {
     }
     
     /**
-     * Gets the app UUID (generates if not exists)
+     * Gets the app UUID. In debug builds returns "dev-debug" so all dev data is grouped.
+     * In release, generates once and persists.
      */
     fun getAppUuid(): String {
+        if (isDevBuild()) return DEV_BUILD_UUID
         var uuid = prefs.getString(KEY_APP_UUID, null)
         if (uuid == null) {
             uuid = java.util.UUID.randomUUID().toString()
@@ -92,8 +103,10 @@ class SettingsPreferences(context: Context) {
 
     /**
      * Sets the app UUID (e.g. when read from the UUID file in the output folder).
+     * No-op in debug builds so "dev-debug" is always used.
      */
     fun setAppUuid(uuid: String) {
+        if (isDevBuild()) return
         prefs.edit { putString(KEY_APP_UUID, uuid) }
     }
     

--- a/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
@@ -5,6 +5,10 @@ import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -14,7 +18,9 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.*
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.OnBackPressedCallback
@@ -232,7 +238,7 @@ class FormEditActivity : AppCompatActivity() {
                         currentPhotoFieldId!!,
                         photoFileName = fileName
                     )
-                    updatePhotoFieldView(currentPhotoFieldId!!, fileName)
+                    updatePhotoFieldView(currentPhotoFieldId!!, fileName, photoFile!!.absolutePath)
                     markFormChanged()
                 }
             }
@@ -241,6 +247,172 @@ class FormEditActivity : AppCompatActivity() {
             currentPhotoFieldId = null
         }
         photoFile = null
+    }
+
+    private val galleryPickerLauncher = registerForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (isDestroyed || isFinishing || uri == null) return@registerForActivityResult
+        val fieldId = currentPhotoFieldId ?: return@registerForActivityResult
+        val photoDir = getPhotoDir()
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                when (uri.scheme) {
+                    "file" -> {
+                        val path = uri.path ?: return@withContext null
+                        val file = File(path)
+                        if (!file.exists() || !file.canRead()) return@withContext null
+                        // If already in app's photo dir, use it as-is (just filename).
+                        if (file.parentFile == photoDir || file.canonicalFile.parentFile == photoDir.canonicalFile) {
+                            Pair(file.name, file.absolutePath)
+                        } else {
+                            // From elsewhere: copy to app dir with app naming scheme, then register in gallery.
+                            copyToAppPhotosDir(uri)?.let { destFile ->
+                                savePhotoToMediaStore(destFile) // so it appears in Pictures/TREC_Logsheets
+                                Pair(destFile.name, destFile.absolutePath)
+                            }
+                        }
+                    }
+                    else -> {
+                        // Content URI: copy to app dir with app naming scheme, then register in gallery.
+                        copyToAppPhotosDir(uri)?.let { destFile ->
+                            savePhotoToMediaStore(destFile) // so it appears in Pictures/TREC_Logsheets
+                            Pair(destFile.name, destFile.absolutePath)
+                        }
+                    }
+                }
+            }
+            if (result != null) {
+                val (fileName, path) = result
+                runOnUiThread {
+                    fieldValues[fieldId] = FormFieldValue(fieldId, photoFileName = fileName)
+                    updatePhotoFieldView(fieldId, fileName, path)
+                    markFormChanged()
+                }
+            } else {
+                runOnUiThread {
+                    Toast.makeText(this@FormEditActivity, getString(R.string.photo_copy_error), Toast.LENGTH_SHORT).show()
+                }
+            }
+            currentPhotoFieldId = null
+        }
+    }
+
+    /** Copies the image from [uri] (file or content) to the app's photos dir with name IMG_yyyyMMdd_HHmmss.jpg. Returns the new file or null on failure. */
+    private fun copyToAppPhotosDir(uri: Uri): File? {
+        return try {
+            val photoDir = getPhotoDir()
+            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+            val destFile = File(photoDir, "IMG_${timestamp}.jpg")
+            val inputStream = when (uri.scheme) {
+                "file" -> uri.path?.let { File(it).inputStream() }
+                else -> contentResolver.openInputStream(uri)
+            }
+            inputStream?.use { input ->
+                destFile.outputStream().use { output -> input.copyTo(output) }
+            }
+            destFile.takeIf { it.exists() }
+        } catch (e: Exception) {
+            android.util.Log.e("FormEditActivity", "Error copying photo to app dir", e)
+            null
+        }
+    }
+    
+    private fun getPhotoDir(): File {
+        val dir = File(getExternalFilesDir(null), "photos")
+        if (!dir.exists()) dir.mkdirs()
+        return dir
+    }
+    
+    /** Resolves a stored photo filename (or full path) to a File. For content URIs use [getPhotoPathOrUri] and open via URI. */
+    private fun getPhotoFileByFileName(fileName: String?): File? {
+        if (fileName.isNullOrBlank()) return null
+        val asFile = File(fileName)
+        if (asFile.isAbsolute && asFile.exists()) return asFile
+        val file = File(getPhotoDir(), fileName)
+        return file.takeIf { it.exists() }
+    }
+
+    /** Returns path for loading/previewing the photo, or null. All photos are stored in app's photo dir. */
+    private fun getPhotoPathOrUri(fieldValue: FormFieldValue?): String? {
+        if (fieldValue == null) return null
+        return getPhotoFileByFileName(fieldValue.photoFileName)?.absolutePath
+    }
+
+    /** Returns display name for the photo (filename only). */
+    private fun getPhotoDisplayName(fieldValue: FormFieldValue?): String? {
+        if (fieldValue?.photoFileName == null) return null
+        val name = fieldValue.photoFileName
+        return if (File(name).isAbsolute) File(name).name else name
+    }
+
+    /**
+     * Clears the selected photo for the field whose view is [photoFieldContainer].
+     * [photoFieldContainer] must be the root view of a photo field (tag = field id).
+     */
+    private fun clearPhotoSelection(photoFieldContainer: View) {
+        val fieldId = photoFieldContainer.tag as? String ?: return
+        fieldValues[fieldId] = FormFieldValue(fieldId, photoFileName = "")
+        photoFieldContainer.findViewById<View>(R.id.photoInfoRow)?.visibility = View.GONE
+    }
+
+    private fun showPhotoPreviewDialog(path: String?) {
+        if (path.isNullOrBlank()) return
+        val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_photo_preview, null)
+        val imagePhoto = dialogView.findViewById<ZoomableImageView>(R.id.imagePhoto)
+        val buttonClose = dialogView.findViewById<ImageButton>(R.id.buttonClosePreview)
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+        dialog.window?.apply {
+            setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+            setBackgroundDrawableResource(android.R.color.black)
+        }
+        buttonClose.setOnClickListener { dialog.dismiss() }
+        lifecycleScope.launch {
+            val bitmap = withContext(Dispatchers.IO) {
+                decodeBitmapWithExifOrientation(path)
+            }
+            runOnUiThread {
+                if (!isDestroyed && !isFinishing && dialog.isShowing && bitmap != null) {
+                    imagePhoto.setImageBitmap(bitmap)
+                }
+            }
+        }
+        dialog.show()
+    }
+
+    /**
+     * Decodes a bitmap from [path] with inSampleSize 2 and applies EXIF orientation
+     * so the image displays with correct rotation (e.g. photos taken in portrait).
+     */
+    private fun decodeBitmapWithExifOrientation(path: String): Bitmap? {
+        val opts = BitmapFactory.Options().apply {
+            inSampleSize = 2
+            inJustDecodeBounds = false
+        }
+        var bitmap = BitmapFactory.decodeFile(path, opts) ?: return null
+        val orientation = try {
+            ExifInterface(path).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL
+            )
+        } catch (_: Exception) {
+            ExifInterface.ORIENTATION_NORMAL
+        }
+        val rotation = when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+            else -> 0f
+        }
+        if (rotation == 0f) return bitmap
+        val matrix = Matrix().apply { postRotate(rotation) }
+        val rotated = Bitmap.createBitmap(
+            bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
+        )
+        if (rotated != bitmap) bitmap.recycle()
+        return rotated
     }
     
     private val requestPermissionLauncher = registerForActivityResult(
@@ -1650,7 +1822,11 @@ class FormEditActivity : AppCompatActivity() {
         
         val textLabel = container.findViewById<TextView>(R.id.textLabel)
         val buttonCapture = container.findViewById<MaterialButton>(R.id.buttonCapture)
+        val buttonChooseFromGallery = container.findViewById<MaterialButton>(R.id.buttonChooseFromGallery)
+        val photoInfoRow = container.findViewById<View>(R.id.photoInfoRow)
         val textFileName = container.findViewById<TextView>(R.id.textFileName)
+        val buttonViewPhoto = container.findViewById<ImageButton>(R.id.buttonViewPhoto)
+        val buttonClearPhoto = container.findViewById<ImageButton>(R.id.buttonClearPhoto)
         
         textLabel.text = if (fieldConfig.required) {
             "${fieldConfig.label} *"
@@ -1660,11 +1836,20 @@ class FormEditActivity : AppCompatActivity() {
         
         container.tag = fieldConfig.id
         
-        // Load existing photo filename
+        buttonViewPhoto?.setOnClickListener {
+            showPhotoPreviewDialog(it.tag as? String)
+        }
+        
+        buttonClearPhoto?.setOnClickListener { clearPhotoSelection(container) }
+        
+        // Load existing photo filename and show view button
         val existingValue = fieldValues[fieldConfig.id]
         if (existingValue?.photoFileName != null) {
-            textFileName.text = getString(R.string.photo_filename, existingValue.photoFileName)
-            textFileName.visibility = View.VISIBLE
+            textFileName.text = getString(R.string.photo_filename, getPhotoDisplayName(existingValue) ?: existingValue.photoFileName)
+            photoInfoRow?.visibility = View.VISIBLE
+            val pathOrUri = getPhotoPathOrUri(existingValue)
+            buttonViewPhoto?.tag = pathOrUri
+            buttonViewPhoto?.visibility = if (pathOrUri != null) View.VISIBLE else View.GONE
         }
         
         if (!isReadOnly) {
@@ -1672,8 +1857,14 @@ class FormEditActivity : AppCompatActivity() {
                 currentPhotoFieldId = fieldConfig.id
                 checkCameraPermissionAndCapture()
             }
+            buttonChooseFromGallery?.setOnClickListener {
+                currentPhotoFieldId = fieldConfig.id
+                galleryPickerLauncher.launch("image/*")
+            }
         } else {
             buttonCapture.isEnabled = false
+            buttonChooseFromGallery?.isEnabled = false
+            buttonClearPhoto?.isEnabled = false
         }
         
         return container
@@ -1696,12 +1887,7 @@ class FormEditActivity : AppCompatActivity() {
     @Suppress("UNUSED_PARAMETER")
     private fun capturePhoto(fieldId: String) {
         try {
-            // Create a file to store the photo
-            val photoDir = File(getExternalFilesDir(null), "photos")
-            if (!photoDir.exists()) {
-                photoDir.mkdirs()
-            }
-            
+            val photoDir = getPhotoDir()
             val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
             val photoFile = File(photoDir, "IMG_${timestamp}.jpg")
             this.photoFile = photoFile
@@ -1752,23 +1938,30 @@ class FormEditActivity : AppCompatActivity() {
         }
     }
     
-    private fun updatePhotoFieldView(fieldId: String, fileName: String) {
-        // Try to find the view in regular fields first
+    private fun updatePhotoFieldView(fieldId: String, fileName: String, pathForPreview: String? = null) {
+        val pathOrUri = pathForPreview ?: getPhotoFileByFileName(fileName)?.absolutePath
+            ?: (if (File(fileName).isAbsolute && File(fileName).exists()) fileName else null)
+        val displayName = if (File(fileName).isAbsolute) File(fileName).name else fileName
         val fieldView = fieldViews[fieldId]
         if (fieldView != null) {
+            val photoInfoRow = fieldView.findViewById<View>(R.id.photoInfoRow)
             val textFileName = fieldView.findViewById<TextView>(R.id.textFileName)
-            textFileName?.text = getString(R.string.photo_filename, fileName)
-            textFileName?.visibility = View.VISIBLE
+            val buttonViewPhoto = fieldView.findViewById<ImageButton>(R.id.buttonViewPhoto)
+            textFileName?.text = getString(R.string.photo_filename, displayName)
+            photoInfoRow?.visibility = View.VISIBLE
+            buttonViewPhoto?.tag = pathOrUri
+            if (pathOrUri == null) buttonViewPhoto?.visibility = View.GONE else buttonViewPhoto?.visibility = View.VISIBLE
             return
         }
-        
-        // If not found, it might be a dynamic widget sub-field
-        // Use findViewWithTag to search the entire view hierarchy
         val photoView = containerFields.findViewWithTag<View>(fieldId)
         if (photoView != null) {
+            val photoInfoRow = photoView.findViewById<View>(R.id.photoInfoRow)
             val textFileName = photoView.findViewById<TextView>(R.id.textFileName)
-            textFileName?.text = getString(R.string.photo_filename, fileName)
-            textFileName?.visibility = View.VISIBLE
+            val buttonViewPhoto = photoView.findViewById<ImageButton>(R.id.buttonViewPhoto)
+            textFileName?.text = getString(R.string.photo_filename, displayName)
+            photoInfoRow?.visibility = View.VISIBLE
+            buttonViewPhoto?.tag = pathOrUri
+            if (pathOrUri == null) buttonViewPhoto?.visibility = View.GONE else buttonViewPhoto?.visibility = View.VISIBLE
         }
     }
     
@@ -2557,7 +2750,11 @@ class FormEditActivity : AppCompatActivity() {
         
         val textLabel = container.findViewById<TextView>(R.id.textLabel)
         val buttonCapture = container.findViewById<MaterialButton>(R.id.buttonCapture)
+        val buttonChooseFromGallery = container.findViewById<MaterialButton>(R.id.buttonChooseFromGallery)
+        val photoInfoRow = container.findViewById<View>(R.id.photoInfoRow)
         val textFileName = container.findViewById<TextView>(R.id.textFileName)
+        val buttonViewPhoto = container.findViewById<ImageButton>(R.id.buttonViewPhoto)
+        val buttonClearPhoto = container.findViewById<ImageButton>(R.id.buttonClearPhoto)
         
         if (textLabel == null || buttonCapture == null || textFileName == null) {
             android.util.Log.e("FormEditActivity", "Failed to find views in field_photo layout")
@@ -2572,11 +2769,20 @@ class FormEditActivity : AppCompatActivity() {
         
         container.tag = uniqueFieldId
         
-        // Load existing photo filename
+        buttonViewPhoto?.setOnClickListener {
+            showPhotoPreviewDialog(it.tag as? String)
+        }
+        
+        buttonClearPhoto?.setOnClickListener { clearPhotoSelection(container) }
+        
+        // Load existing photo filename and show view button
         val existingValue = fieldValues[uniqueFieldId]
         if (existingValue?.photoFileName != null) {
-            textFileName.text = getString(R.string.photo_filename, existingValue.photoFileName)
-            textFileName.visibility = View.VISIBLE
+            textFileName.text = getString(R.string.photo_filename, getPhotoDisplayName(existingValue) ?: existingValue.photoFileName)
+            photoInfoRow?.visibility = View.VISIBLE
+            val pathOrUri = getPhotoPathOrUri(existingValue)
+            buttonViewPhoto?.tag = pathOrUri
+            buttonViewPhoto?.visibility = if (pathOrUri != null) View.VISIBLE else View.GONE
         }
         
         if (!isReadOnly) {
@@ -2584,8 +2790,14 @@ class FormEditActivity : AppCompatActivity() {
                 currentPhotoFieldId = uniqueFieldId
                 checkCameraPermissionAndCapture()
             }
+            buttonChooseFromGallery?.setOnClickListener {
+                currentPhotoFieldId = uniqueFieldId
+                galleryPickerLauncher.launch("image/*")
+            }
         } else {
             buttonCapture.isEnabled = false
+            buttonChooseFromGallery?.isEnabled = false
+            buttonClearPhoto?.isEnabled = false
         }
         
         return container
@@ -3351,6 +3563,20 @@ class FormEditActivity : AppCompatActivity() {
                 }
                 if (fieldValue.gpsLongitude != null) {
                     editTextLongitude?.setText(fieldValue.gpsLongitude.toString())
+                }
+            }
+            FormFieldConfig.FieldType.PHOTO -> {
+                val fileName = fieldValue.photoFileName
+                if (!fileName.isNullOrBlank()) {
+                    val photoInfoRow = fieldView.findViewById<View>(R.id.photoInfoRow)
+                    val textFileName = fieldView.findViewById<TextView>(R.id.textFileName)
+                    val buttonViewPhoto = fieldView.findViewById<ImageButton>(R.id.buttonViewPhoto)
+                    val displayName = getPhotoDisplayName(fieldValue) ?: fileName
+                    val pathOrUri = getPhotoPathOrUri(fieldValue)
+                    textFileName?.text = getString(R.string.photo_filename, displayName)
+                    photoInfoRow?.visibility = View.VISIBLE
+                    buttonViewPhoto?.tag = pathOrUri
+                    buttonViewPhoto?.visibility = if (pathOrUri != null) View.VISIBLE else View.GONE
                 }
             }
             FormFieldConfig.FieldType.DYNAMIC -> {

--- a/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
@@ -905,6 +905,7 @@ class FormEditActivity : AppCompatActivity() {
                 FormFieldConfig.FieldType.TEXTAREA -> createTextAreaField(fieldConfig)
                 FormFieldConfig.FieldType.DATE -> createDateField(fieldConfig)
                 FormFieldConfig.FieldType.TIME -> createTimeField(fieldConfig)
+                FormFieldConfig.FieldType.TIMEPICKER -> createTimepickerField(fieldConfig)
                 FormFieldConfig.FieldType.SELECT -> createSelectField(fieldConfig)
                 FormFieldConfig.FieldType.MULTISELECT -> createMultiSelectField(fieldConfig)
                 FormFieldConfig.FieldType.SELECT_IMAGE -> createSelectImageField(fieldConfig)
@@ -1215,7 +1216,7 @@ class FormEditActivity : AppCompatActivity() {
     private fun createTimeField(fieldConfig: FormFieldConfig): View {
         val (textInputLayout, editText) = inflateTextInputField(fieldConfig)
         // Don't set hint on EditText - only on TextInputLayout to avoid overlap
-        
+
         // Read-only: allow focus and selection for copying, but not editing
         if (isReadOnly) {
             editText.setKeyListener(null)
@@ -1227,8 +1228,56 @@ class FormEditActivity : AppCompatActivity() {
                 showTimePicker(fieldConfig.id, editText)
             }
         }
-        
+
         return textInputLayout
+    }
+
+    /** Timepicker: shows value (HH:MM:SS) in the list; click opens pop-up with spinners and Save/Clear/Cancel. */
+    private fun createTimepickerField(fieldConfig: FormFieldConfig): View {
+        val (textInputLayout, editText) = inflateTextInputField(fieldConfig)
+        editText.setText("00:00:00")
+        editText.isFocusable = false
+        editText.isClickable = true
+
+        if (isReadOnly) {
+            editText.setKeyListener(null)
+            editText.setTextIsSelectable(true)
+        } else {
+            editText.setOnClickListener {
+                showTimepickerDialog(fieldConfig.id, editText, null)
+            }
+        }
+
+        fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = "00:00:00")
+        return textInputLayout
+    }
+
+    private fun setupTimepickerSpinners(
+        numberPickerHours: NumberPicker,
+        numberPickerMinutes: NumberPicker,
+        numberPickerSeconds: NumberPicker
+    ) {
+        val displayedValues = (0..59).map { String.format(Locale.US, "%02d", it) }.toTypedArray()
+        for (picker in listOf(numberPickerHours, numberPickerMinutes, numberPickerSeconds)) {
+            picker.minValue = 0
+            picker.maxValue = 59
+            picker.displayedValues = displayedValues
+            picker.value = 0
+            picker.wrapSelectorWheel = false
+        }
+    }
+
+    private fun formatTimepickerValue(hours: Int, minutes: Int, seconds: Int): String {
+        return String.format(Locale.US, "%02d:%02d:%02d", hours, minutes, seconds)
+    }
+
+    private fun parseTimepickerValue(value: String?): Triple<Int, Int, Int> {
+        if (value.isNullOrBlank()) return Triple(0, 0, 0)
+        val parts = value.trim().split(":")
+        val h = parts.getOrNull(0)?.toIntOrNull()?.coerceIn(0, 59) ?: 0
+        val m = parts.getOrNull(1)?.toIntOrNull()?.coerceIn(0, 59) ?: 0
+        val s = parts.getOrNull(2)?.toIntOrNull()?.coerceIn(0, 59) ?: 0
+        return Triple(h, m, s)
     }
     
     private fun createSelectField(fieldConfig: FormFieldConfig): View {
@@ -2239,6 +2288,7 @@ class FormEditActivity : AppCompatActivity() {
                 FormFieldConfig.FieldType.TEXTAREA -> createTextAreaFieldForSubField(subFieldConfig, uniqueFieldId, parent)
                 FormFieldConfig.FieldType.DATE -> createDateFieldForSubField(subFieldConfig, uniqueFieldId, parent)
                 FormFieldConfig.FieldType.TIME -> createTimeFieldForSubField(subFieldConfig, uniqueFieldId, parent)
+                FormFieldConfig.FieldType.TIMEPICKER -> createTimepickerFieldForSubField(subFieldConfig, uniqueFieldId, parent)
                 FormFieldConfig.FieldType.SELECT -> createSelectFieldForSubField(subFieldConfig, uniqueFieldId, parent)
                 FormFieldConfig.FieldType.MULTISELECT -> createMultiSelectFieldForSubField(subFieldConfig, uniqueFieldId, parent)
                 FormFieldConfig.FieldType.GPS -> createGPSFieldForSubField(subFieldConfig, uniqueFieldId, parent)
@@ -2385,6 +2435,27 @@ class FormEditActivity : AppCompatActivity() {
             editText.setTextIsSelectable(true)
         }
         
+        return textInputLayout
+    }
+
+    private fun createTimepickerFieldForSubField(fieldConfig: FormFieldConfig, uniqueFieldId: String, parent: ViewGroup): View {
+        val (textInputLayout, editText) = inflateTextInputFieldInto(fieldConfig, parent, uniqueFieldId)
+        editText.setText("00:00:00")
+        editText.isFocusable = false
+        editText.isClickable = true
+
+        if (!isReadOnly) {
+            editText.setOnClickListener {
+                showTimepickerDialog(uniqueFieldId, editText) {
+                    dynamicFieldIdFromFormKey(uniqueFieldId)?.let { updateAddButtonForDynamicField(it) }
+                }
+            }
+        } else {
+            editText.setKeyListener(null)
+            editText.setTextIsSelectable(true)
+        }
+
+        fieldValues[uniqueFieldId] = FormFieldValue(uniqueFieldId, value = "00:00:00")
         return textInputLayout
     }
     
@@ -2728,6 +2799,7 @@ class FormEditActivity : AppCompatActivity() {
             FormFieldConfig.FieldType.TEXTAREA,
             FormFieldConfig.FieldType.DATE,
             FormFieldConfig.FieldType.TIME,
+            FormFieldConfig.FieldType.TIMEPICKER,
             FormFieldConfig.FieldType.SELECT,
             FormFieldConfig.FieldType.BARCODE -> {
                 val editText = subFieldView.findViewById<TextInputEditText>(R.id.editText)
@@ -3003,6 +3075,54 @@ class FormEditActivity : AppCompatActivity() {
             dynamicFieldIdFromFormKey(fieldId)?.let { updateAddButtonForDynamicField(it) }
         }
     }
+
+    /**
+     * Shows the timepicker pop-up (hours, minutes, seconds 0–60). On Save, updates [editText] and [fieldValues].
+     * [onAfterValueSet] is called after save (e.g. to refresh dynamic add button).
+     */
+    private fun showTimepickerDialog(fieldId: String, editText: TextInputEditText, onAfterValueSet: (() -> Unit)?) {
+        val currentValue = editText.text?.toString()?.trim()?.takeIf { it.isNotEmpty() } ?: "00:00:00"
+        val (h, m, s) = parseTimepickerValue(currentValue)
+
+        val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_timepicker, null)
+        val numberPickerHours = dialogView.findViewById<NumberPicker>(R.id.numberPickerHours)
+        val numberPickerMinutes = dialogView.findViewById<NumberPicker>(R.id.numberPickerMinutes)
+        val numberPickerSeconds = dialogView.findViewById<NumberPicker>(R.id.numberPickerSeconds)
+        val buttonClear = dialogView.findViewById<com.google.android.material.button.MaterialButton>(R.id.buttonClear)
+        val buttonCancel = dialogView.findViewById<com.google.android.material.button.MaterialButton>(R.id.buttonCancel)
+        val buttonSave = dialogView.findViewById<com.google.android.material.button.MaterialButton>(R.id.buttonSave)
+
+        setupTimepickerSpinners(numberPickerHours, numberPickerMinutes, numberPickerSeconds)
+        numberPickerHours.value = h
+        numberPickerMinutes.value = m
+        numberPickerSeconds.value = s
+
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .setTitle(R.string.timepicker_dialog_title)
+            .create()
+
+        buttonClear.setOnClickListener {
+            numberPickerHours.value = 0
+            numberPickerMinutes.value = 0
+            numberPickerSeconds.value = 0
+        }
+        buttonCancel.setOnClickListener { dialog.dismiss() }
+        buttonSave.setOnClickListener {
+            val value = formatTimepickerValue(
+                numberPickerHours.value,
+                numberPickerMinutes.value,
+                numberPickerSeconds.value
+            )
+            editText.setText(value)
+            fieldValues[fieldId] = FormFieldValue(fieldId, value = value)
+            markFormChanged()
+            onAfterValueSet?.invoke()
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
     
     private fun showSelectDialog(fieldConfig: FormFieldConfig, editText: TextInputEditText) {
         val options = fieldConfig.options ?: return
@@ -3203,6 +3323,10 @@ class FormEditActivity : AppCompatActivity() {
                     editText?.setText(value)
                 }
             }
+            FormFieldConfig.FieldType.TIMEPICKER -> {
+                val editText = fieldView.findViewById<TextInputEditText>(R.id.editText)
+                editText?.setText(fieldValue.value ?: "00:00:00")
+            }
             FormFieldConfig.FieldType.SELECT -> {
                 val editText = fieldView.findViewById<TextInputEditText>(R.id.editText)
                 editText?.setText(fieldValue.value)
@@ -3350,6 +3474,13 @@ class FormEditActivity : AppCompatActivity() {
                     editText?.setText(timeValue)
                     fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = timeValue)
                 }
+
+                FormFieldConfig.FieldType.TIMEPICKER -> {
+                    val value = parseTimepickerValue(defaultValue).let { (h, m, s) -> formatTimepickerValue(h, m, s) }
+                    val editText = fieldView.findViewById<TextInputEditText>(R.id.editText)
+                    editText?.setText(value)
+                    fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = value)
+                }
                 
                 else -> {
                     // Default values not supported for this field type
@@ -3465,6 +3596,13 @@ class FormEditActivity : AppCompatActivity() {
                     editText?.setText(timeValue)
                     fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = timeValue)
                 }
+
+                FormFieldConfig.FieldType.TIMEPICKER -> {
+                    val value = parseTimepickerValue(prefillValue).let { (h, m, s) -> formatTimepickerValue(h, m, s) }
+                    val editText = fieldView.findViewById<TextInputEditText>(R.id.editText)
+                    editText?.setText(value)
+                    fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = value)
+                }
                 
                 else -> {
                     // Prefills not supported for this field type
@@ -3524,6 +3662,11 @@ class FormEditActivity : AppCompatActivity() {
                     if (value.isNotEmpty()) {
                         values.add(FormFieldValue(fieldId, value = value))
                     }
+                }
+                FormFieldConfig.FieldType.TIMEPICKER -> {
+                    val editText = fieldView.findViewById<TextInputEditText>(R.id.editText)
+                    val value = editText?.text?.toString()?.trim() ?: "00:00:00"
+                    values.add(FormFieldValue(fieldId, value = value))
                 }
                 FormFieldConfig.FieldType.CHECKBOX -> {
                     val checkbox = fieldView.findViewById<CheckBox>(R.id.checkbox)
@@ -3706,6 +3849,7 @@ class FormEditActivity : AppCompatActivity() {
                 FormFieldConfig.FieldType.TEXTAREA,
                 FormFieldConfig.FieldType.DATE,
                 FormFieldConfig.FieldType.TIME,
+                FormFieldConfig.FieldType.TIMEPICKER,
                 FormFieldConfig.FieldType.SELECT,
                 FormFieldConfig.FieldType.SELECT_IMAGE,
                 FormFieldConfig.FieldType.BARCODE -> {
@@ -3785,6 +3929,7 @@ class FormEditActivity : AppCompatActivity() {
                                 FormFieldConfig.FieldType.TEXTAREA,
                                 FormFieldConfig.FieldType.DATE,
                                 FormFieldConfig.FieldType.TIME,
+                                FormFieldConfig.FieldType.TIMEPICKER,
                                 FormFieldConfig.FieldType.SELECT,
                                 FormFieldConfig.FieldType.BARCODE ->
                                     subFieldValue?.value?.trim()?.isEmpty() ?: true

--- a/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
@@ -3343,6 +3343,11 @@ class FormEditActivity : AppCompatActivity() {
                 fieldValues[fieldConfig.id] = FormFieldValue(fieldConfig.id, value = selectedValue)
                 markFormChanged()
             }
+            .setNegativeButton(getString(R.string.clear)) { _, _ ->
+                editText.setText("")
+                fieldValues.remove(fieldConfig.id)
+                markFormChanged()
+            }
             .show()
     }
     
@@ -3355,6 +3360,12 @@ class FormEditActivity : AppCompatActivity() {
                 val selectedValue = options[which]
                 editText.setText(selectedValue)
                 fieldValues[uniqueFieldId] = FormFieldValue(uniqueFieldId, value = selectedValue)
+                markFormChanged()
+                dynamicFieldIdFromFormKey(uniqueFieldId)?.let { updateAddButtonForDynamicField(it) }
+            }
+            .setNegativeButton(getString(R.string.clear)) { _, _ ->
+                editText.setText("")
+                fieldValues.remove(uniqueFieldId)
                 markFormChanged()
                 dynamicFieldIdFromFormKey(uniqueFieldId)?.let { updateAddButtonForDynamicField(it) }
             }

--- a/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
@@ -352,7 +352,7 @@ class FormEditActivity : AppCompatActivity() {
      */
     private fun clearPhotoSelection(photoFieldContainer: View) {
         val fieldId = photoFieldContainer.tag as? String ?: return
-        fieldValues[fieldId] = FormFieldValue(fieldId, photoFileName = "")
+        fieldValues[fieldId] = FormFieldValue(fieldId, photoFileName = null)
         photoFieldContainer.findViewById<View>(R.id.photoInfoRow)?.visibility = View.GONE
     }
 

--- a/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormEditActivity.kt
@@ -17,6 +17,7 @@ import android.view.ViewGroup
 import android.widget.*
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
@@ -394,6 +395,17 @@ class FormEditActivity : AppCompatActivity() {
         renderFields()
         setupFocusChangeDebounce()
         initialFormStateSignature = computeFormStateSignature()
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (hasUnsavedChanges()) {
+                    showSaveChangesDialog()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        })
     }
     
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -433,24 +445,8 @@ class FormEditActivity : AppCompatActivity() {
             if (isReadOnly) {
                 finish() // No need to check for unsaved changes in read-only mode
             } else {
-                handleBackPress()
+                onBackPressedDispatcher.onBackPressed()
             }
-        }
-    }
-    
-    override fun onBackPressed() {
-        if (hasUnsavedChanges()) {
-            showSaveChangesDialog()
-        } else {
-            super.onBackPressed()
-        }
-    }
-    
-    private fun handleBackPress() {
-        if (hasUnsavedChanges()) {
-            showSaveChangesDialog()
-        } else {
-            super.onBackPressed()
         }
     }
     

--- a/app/src/main/java/com/trec/trecollect/ui/FormSectionAdapter.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/FormSectionAdapter.kt
@@ -138,7 +138,6 @@ class FormSectionAdapter(
             // Find and notify all items in this dynamic group to rebind
             // Each item will recalculate its own form key and check the updated status sets
             val currentList = formAdapter.currentList
-            val baseFormName = form.name.substringBefore(" #")
             
             // Find all instances of this dynamic form (only FormItem, skip AddButtonItem)
             val startIndex = currentList.indexOfFirst { item ->
@@ -322,7 +321,8 @@ class FormSectionAdapter(
             return "${form.id}_${instanceIndex}_$subIndex"
         }
 
-        fun addDynamicFormInstance(baseForm: Form, subIndex: Int) {
+        @Suppress("UNUSED_PARAMETER")
+        fun addDynamicFormInstance(baseForm: Form, _subIndex: Int) {
             // Get current list
             val currentList = formAdapter.currentList.toMutableList()
             val (lastInstanceIndex, addButtonIndex) = findLastInstanceAndAddButtonIndex(currentList, baseForm)

--- a/app/src/main/java/com/trec/trecollect/ui/MainViewModel.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/MainViewModel.kt
@@ -401,6 +401,8 @@ class MainViewModel(
                 _finishedSites.value = current
             }
             loadSitesFromFolders(force = true)
+            // Do not call loadSitesFromFolders here: we already updated _finishedSites in-place.
+            // A full reload from disk can overwrite with empty/stale data (e.g. in tests or when folder is not ready).
         } catch (e: Exception) {
             AppLogger.e("MainViewModel", "Error updating site upload status: ${e.message}", e)
         }

--- a/app/src/main/java/com/trec/trecollect/ui/MainViewModel.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/MainViewModel.kt
@@ -255,7 +255,7 @@ class MainViewModel(
             return CreateSiteResult.Error("Storage folder not configured. Please select a folder in Settings.")
         }
         
-        // Try to get the TREC_logsheets folder (the stored URI should point to TREC_logsheets)
+        // Try to get the TRECollect_logsheets folder (the stored URI should point to TRECollect_logsheets)
         val trecFolder = try {
             folderHelper.getTrecLogsheetsFolder(settingsPreferences)
         } catch (e: Exception) {
@@ -263,28 +263,28 @@ class MainViewModel(
         }
         
         if (trecFolder == null) {
-            return CreateSiteResult.Error("TREC_logsheets folder not found. Please reconfigure storage in Settings.")
+            return CreateSiteResult.Error("TRECollect_logsheets folder not found. Please reconfigure storage in Settings.")
         }
         
-        // CRITICAL: Verify we have the TREC_logsheets folder by checking its name
+        // CRITICAL: Verify we have the TRECollect_logsheets folder by checking its name
         val folderName = trecFolder.name
             AppLogger.d("MainViewModel", "Retrieved folder name: '$folderName', expected: '${FolderStructureHelper.PARENT_FOLDER_NAME}'")
         
         if (folderName != FolderStructureHelper.PARENT_FOLDER_NAME) {
-            // The URI might point to the parent folder, try to find TREC_logsheets inside it
-            AppLogger.w("MainViewModel", "Folder name mismatch! Looking for TREC_logsheets inside '$folderName'...")
+            // The URI might point to the parent folder, try to find TRECollect_logsheets inside it
+            AppLogger.w("MainViewModel", "Folder name mismatch! Looking for TRECollect_logsheets inside '$folderName'...")
             val actualTrecFolder = trecFolder.findFile(FolderStructureHelper.PARENT_FOLDER_NAME)
             if (actualTrecFolder != null && actualTrecFolder.exists()) {
-                AppLogger.d("MainViewModel", "Found TREC_logsheets inside parent folder")
-                // Use the actual TREC_logsheets folder
+                AppLogger.d("MainViewModel", "Found TRECollect_logsheets inside parent folder")
+                // Use the actual TRECollect_logsheets folder
                 val verifiedTrecFolder = actualTrecFolder
                 return createSiteInFolder(trimmedName, verifiedTrecFolder)
             } else {
-                return CreateSiteResult.Error("TREC_logsheets folder not found. The stored URI points to '$folderName' instead. Please reconfigure storage in Settings.")
+                return CreateSiteResult.Error("TRECollect_logsheets folder not found. The stored URI points to '$folderName' instead. Please reconfigure storage in Settings.")
             }
         }
         
-        // Continue with the verified TREC_logsheets folder
+        // Continue with the verified TRECollect_logsheets folder
         return createSiteInFolder(trimmedName, trecFolder)
     }
 
@@ -431,9 +431,9 @@ class MainViewModel(
     }
     
     private suspend fun createSiteInFolder(siteName: String, trecFolder: DocumentFile): CreateSiteResult {
-        // Check if TREC_logsheets folder exists and is accessible (name already verified by createSite() caller)
+        // Check if TRECollect_logsheets folder exists and is accessible (name already verified by createSite() caller)
         if (!trecFolder.canRead() || !trecFolder.canWrite()) {
-            return CreateSiteResult.Error("Cannot access TREC_logsheets folder. Please check permissions in Settings.")
+            return CreateSiteResult.Error("Cannot access TRECollect_logsheets folder. Please check permissions in Settings.")
         }
 
         val (ongoingFolder, folderError) = getOngoingFolderForWrite()
@@ -461,7 +461,7 @@ class MainViewModel(
         val createdFolder = ongoingFolder.createDirectory(siteName)
         if (createdFolder == null) {
             AppLogger.e("MainViewModel", "Failed to create site folder: name='$siteName'")
-            return CreateSiteResult.Error("Could not create site folder in TREC_logsheets/ongoing/")
+            return CreateSiteResult.Error("Could not create site folder in TRECollect_logsheets/ongoing/")
         }
         
         // If created folder name differs from requested, treat as error and remove wrong folder

--- a/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
@@ -53,8 +53,13 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var teamAdapter: ArrayAdapter<String>
     private lateinit var subteamAdapter: ArrayAdapter<String>
     
+    /** Debounce: avoid creating team/subteam folders twice when team and subteam both trigger verify. */
+    private var lastVerifiedTeamSubteam: Pair<String, String>? = null
+    private var lastVerifiedTimeMs: Long = 0
+    
     companion object {
         private const val REQUEST_CODE_OPEN_FOLDER = 1001
+        private const val VERIFY_DEBOUNCE_MS = 2000L
     }
     
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -555,16 +560,20 @@ class SettingsActivity : AppCompatActivity() {
             // Ensure UUID file in output folder: write current UUID if new, else read and use existing
             folderHelper.ensureUuidFileInOutputFolder(trecFolder, settingsPreferences)
             
-            // Only create deeper structure (team/subteam) if team and subteam are set
+            // Create team/subteam/ongoing/finished/deleted only when needed, and only once:
+            // - If we used ensureFolderStructure (parent folder selected), it already created them — do not call ensureSubfoldersExist.
+            // - If we used docFile directly (user selected TRECollect_logsheets), create structure under this trecFolder.
             if (team.isNotEmpty() && subteam.isNotEmpty()) {
-                android.util.Log.d("SettingsActivity", "Team and subteam are set, creating deeper folder structure...")
-                // Ensure subfolders exist (team/subteam/ongoing/finished/deleted)
-                // This will create team/subteam folders inside TRECollect_logsheets
-                if (!folderHelper.ensureSubfoldersExist(settingsPreferences)) {
-                    android.util.Log.w("SettingsActivity", "Could not ensure all subfolders exist")
-                    Toast.makeText(this, "Warning: Could not create all subfolders", Toast.LENGTH_SHORT).show()
+                if (isTrecFolder) {
+                    android.util.Log.d("SettingsActivity", "Team and subteam set, creating deeper folder structure under selected TRECollect_logsheets...")
+                    if (!folderHelper.ensureSubfoldersExist(trecFolder, settingsPreferences)) {
+                        android.util.Log.w("SettingsActivity", "Could not ensure all subfolders exist")
+                        Toast.makeText(this, "Warning: Could not create all subfolders", Toast.LENGTH_SHORT).show()
+                    } else {
+                        android.util.Log.i("SettingsActivity", "Deeper folder structure created successfully")
+                    }
                 } else {
-                    android.util.Log.i("SettingsActivity", "Deeper folder structure created successfully")
+                    android.util.Log.d("SettingsActivity", "Team and subteam set; structure already created via ensureFolderStructure")
                 }
             } else {
                 android.util.Log.i("SettingsActivity", "Team or subteam not set yet - TRECollect_logsheets folder created, deeper structure will be created later")
@@ -616,9 +625,20 @@ class SettingsActivity : AppCompatActivity() {
     /**
      * Verifies that the folder structure exists without recreating it.
      * This is called when team/subteam changes to ensure structure is still valid.
-     * Only ensures subfolders exist, doesn't recreate TRECollect_logsheets or team/subteam folders.
+     * Debounced so we don't create folders twice when both team and subteam triggers fire (e.g. team callback + subteam onItemSelected).
      */
     private fun verifyFolderStructure(uri: Uri) {
+        val team = settingsPreferences.getSamplingTeam()
+        val subteam = settingsPreferences.getSamplingSubteam()
+        if (team.isEmpty() || subteam.isEmpty()) return
+        val key = Pair(team, subteam)
+        val now = System.currentTimeMillis()
+        if (lastVerifiedTeamSubteam == key && (now - lastVerifiedTimeMs) < VERIFY_DEBOUNCE_MS) {
+            android.util.Log.d("SettingsActivity", "verifyFolderStructure: skip (debounce) for $team / $subteam")
+            return
+        }
+        lastVerifiedTeamSubteam = key
+        lastVerifiedTimeMs = now
         try {
             val folderHelper = FolderStructureHelper(this)
             val docFile = DocumentFile.fromTreeUri(this, uri)
@@ -626,15 +646,13 @@ class SettingsActivity : AppCompatActivity() {
             // Check if URI points to TRECollect_logsheets folder
             if (docFile?.name == FolderStructureHelper.PARENT_FOLDER_NAME) {
                 // URI points to TRECollect_logsheets, just verify subfolders exist (team/subteam/ongoing/finished/deleted)
-                // This won't recreate anything, just ensures the subfolders exist
                 if (!folderHelper.ensureSubfoldersExist(settingsPreferences)) {
                     android.util.Log.w("SettingsActivity", "Some subfolders could not be verified/created")
+                    lastVerifiedTeamSubteam = null // allow retry
                 } else {
                     android.util.Log.d("SettingsActivity", "Folder structure verified successfully")
                 }
             } else {
-                // URI points to parent folder - structure should already exist
-                // Don't do anything, just log
                 android.util.Log.d("SettingsActivity", "URI points to parent folder, structure should already exist")
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
@@ -552,6 +552,9 @@ class SettingsActivity : AppCompatActivity() {
             
             android.util.Log.i("SettingsActivity", "TRECollect_logsheets folder ready: ${trecFolder.uri}")
             
+            // Ensure UUID file in output folder: write current UUID if new, else read and use existing
+            folderHelper.ensureUuidFileInOutputFolder(trecFolder, settingsPreferences)
+            
             // Only create deeper structure (team/subteam) if team and subteam are set
             if (team.isNotEmpty() && subteam.isNotEmpty()) {
                 android.util.Log.d("SettingsActivity", "Team and subteam are set, creating deeper folder structure...")

--- a/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
@@ -501,7 +501,7 @@ class SettingsActivity : AppCompatActivity() {
             
             android.util.Log.d("SettingsActivity", "Current team: '$team', subteam: '$subteam'")
             
-            // Check if the URI already points to TREC_logsheets folder
+            // Check if the URI already points to TRECollect_logsheets folder
             val docFile = DocumentFile.fromTreeUri(this, baseUri)
             if (docFile == null) {
                 android.util.Log.e("SettingsActivity", "Could not create DocumentFile from URI: $baseUri")
@@ -514,49 +514,49 @@ class SettingsActivity : AppCompatActivity() {
             
             android.util.Log.d("SettingsActivity", "createFolderStructure: baseUri=$baseUri, folder name='$folderName', isTrecFolder=$isTrecFolder")
             
-            // ALWAYS create TREC_logsheets folder, even if team/subteam are not set yet
+            // ALWAYS create TRECollect_logsheets folder, even if team/subteam are not set yet
             // The deeper structure (team/subteam) will be created later when they are configured
             val trecFolder = if (isTrecFolder) {
-                // URI already points to TREC_logsheets, use it directly - don't recreate
-                android.util.Log.i("SettingsActivity", "URI already points to TREC_logsheets folder, using existing folder")
+                // URI already points to TRECollect_logsheets, use it directly - don't recreate
+                android.util.Log.i("SettingsActivity", "URI already points to TRECollect_logsheets folder, using existing folder")
                 docFile
             } else {
-                // URI points to parent folder, create TREC_logsheets inside it (only if it doesn't exist)
-                android.util.Log.i("SettingsActivity", "URI points to parent folder '$folderName', creating TREC_logsheets inside it")
+                // URI points to parent folder, create TRECollect_logsheets inside it (only if it doesn't exist)
+                android.util.Log.i("SettingsActivity", "URI points to parent folder '$folderName', creating TRECollect_logsheets inside it")
                 val createdTrecFolder = folderHelper.ensureFolderStructure(baseUri, settingsPreferences)
                 if (createdTrecFolder == null) {
-                    android.util.Log.e("SettingsActivity", "Failed to create TREC_logsheets folder in '$folderName'")
-                    Toast.makeText(this, "Error: Could not create TREC_logsheets folder. Please try selecting the folder again.", Toast.LENGTH_LONG).show()
+                    android.util.Log.e("SettingsActivity", "Failed to create TRECollect_logsheets folder in '$folderName'")
+                    Toast.makeText(this, "Error: Could not create TRECollect_logsheets folder. Please try selecting the folder again.", Toast.LENGTH_LONG).show()
                     return
                 }
-                android.util.Log.i("SettingsActivity", "TREC_logsheets folder created successfully: ${createdTrecFolder.uri}")
-                // Verify the created folder is actually TREC_logsheets and is accessible
+                android.util.Log.i("SettingsActivity", "TRECollect_logsheets folder created successfully: ${createdTrecFolder.uri}")
+                // Verify the created folder is actually TRECollect_logsheets and is accessible
                 if (createdTrecFolder.name != FolderStructureHelper.PARENT_FOLDER_NAME) {
                     android.util.Log.e("SettingsActivity", "Created folder has wrong name: '${createdTrecFolder.name}', expected '${FolderStructureHelper.PARENT_FOLDER_NAME}'")
                     Toast.makeText(this, "Error: Created folder has unexpected name: '${createdTrecFolder.name}'. Please try again.", Toast.LENGTH_LONG).show()
                     return
                 }
                 if (!createdTrecFolder.exists() || !createdTrecFolder.canWrite()) {
-                    android.util.Log.e("SettingsActivity", "Created TREC_logsheets folder exists but is not accessible or writable")
-                    Toast.makeText(this, "Error: TREC_logsheets folder is not accessible. Please try selecting the folder again.", Toast.LENGTH_LONG).show()
+                    android.util.Log.e("SettingsActivity", "Created TRECollect_logsheets folder exists but is not accessible or writable")
+                    Toast.makeText(this, "Error: TRECollect_logsheets folder is not accessible. Please try selecting the folder again.", Toast.LENGTH_LONG).show()
                     return
                 }
                 createdTrecFolder
             }
             
-            // Verify we have the TREC_logsheets folder
+            // Verify we have the TRECollect_logsheets folder
             if (trecFolder.name != FolderStructureHelper.PARENT_FOLDER_NAME) {
                 android.util.Log.w("SettingsActivity", "Warning: Folder name is '${trecFolder.name}', expected '${FolderStructureHelper.PARENT_FOLDER_NAME}'")
                 Toast.makeText(this, "Warning: Folder structure may be incorrect", Toast.LENGTH_LONG).show()
             }
             
-            android.util.Log.i("SettingsActivity", "TREC_logsheets folder ready: ${trecFolder.uri}")
+            android.util.Log.i("SettingsActivity", "TRECollect_logsheets folder ready: ${trecFolder.uri}")
             
             // Only create deeper structure (team/subteam) if team and subteam are set
             if (team.isNotEmpty() && subteam.isNotEmpty()) {
                 android.util.Log.d("SettingsActivity", "Team and subteam are set, creating deeper folder structure...")
                 // Ensure subfolders exist (team/subteam/ongoing/finished/deleted)
-                // This will create team/subteam folders inside TREC_logsheets
+                // This will create team/subteam folders inside TRECollect_logsheets
                 if (!folderHelper.ensureSubfoldersExist(settingsPreferences)) {
                     android.util.Log.w("SettingsActivity", "Could not ensure all subfolders exist")
                     Toast.makeText(this, "Warning: Could not create all subfolders", Toast.LENGTH_SHORT).show()
@@ -564,32 +564,32 @@ class SettingsActivity : AppCompatActivity() {
                     android.util.Log.i("SettingsActivity", "Deeper folder structure created successfully")
                 }
             } else {
-                android.util.Log.i("SettingsActivity", "Team or subteam not set yet - TREC_logsheets folder created, deeper structure will be created later")
+                android.util.Log.i("SettingsActivity", "Team or subteam not set yet - TRECollect_logsheets folder created, deeper structure will be created later")
             }
             
-            // Get the URI for the TREC_logsheets folder directly from the DocumentFile
+            // Get the URI for the TRECollect_logsheets folder directly from the DocumentFile
             val trecFolderUri = trecFolder.uri
             
-            // Also take persistable permission for the TREC_logsheets folder
+            // Also take persistable permission for the TRECollect_logsheets folder
             try {
                 contentResolver.takePersistableUriPermission(
                     trecFolderUri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
                 )
             } catch (e: Exception) {
-                android.util.Log.w("SettingsActivity", "Could not take persistable permission for TREC_logsheets: ${e.message}")
+                android.util.Log.w("SettingsActivity", "Could not take persistable permission for TRECollect_logsheets: ${e.message}")
             }
             
-            // Save the tree URI - this should point to TREC_logsheets folder
+            // Save the tree URI - this should point to TRECollect_logsheets folder
             settingsPreferences.setFolderUri(trecFolderUri.toString())
             
             // Verify we're saving the correct URI
-            android.util.Log.d("SettingsActivity", "Saved TREC_logsheets URI: $trecFolderUri")
-            android.util.Log.d("SettingsActivity", "TREC_logsheets folder name: ${trecFolder.name}")
+            android.util.Log.d("SettingsActivity", "Saved TRECollect_logsheets URI: $trecFolderUri")
+            android.util.Log.d("SettingsActivity", "TRECollect_logsheets folder name: ${trecFolder.name}")
             
             // Display the path with structure info (all teams use subteam structure now)
             val fullPath = getFullPath(trecFolderUri, trecFolder)
-            val structureInfo = "\n\nStructure:\n• TREC_logsheets/\n  - $team/\n    - $subteam/\n      - ongoing/\n      - finished/\n      - deleted/"
+            val structureInfo = "\n\nStructure:\n• TRECollect_logsheets/\n  - $team/\n    - $subteam/\n      - ongoing/\n      - finished/\n      - deleted/"
             folderPathText.text = fullPath + structureInfo
             
             // Make it visually obvious that folder is selected
@@ -613,16 +613,16 @@ class SettingsActivity : AppCompatActivity() {
     /**
      * Verifies that the folder structure exists without recreating it.
      * This is called when team/subteam changes to ensure structure is still valid.
-     * Only ensures subfolders exist, doesn't recreate TREC_logsheets or team/subteam folders.
+     * Only ensures subfolders exist, doesn't recreate TRECollect_logsheets or team/subteam folders.
      */
     private fun verifyFolderStructure(uri: Uri) {
         try {
             val folderHelper = FolderStructureHelper(this)
             val docFile = DocumentFile.fromTreeUri(this, uri)
             
-            // Check if URI points to TREC_logsheets folder
+            // Check if URI points to TRECollect_logsheets folder
             if (docFile?.name == FolderStructureHelper.PARENT_FOLDER_NAME) {
-                // URI points to TREC_logsheets, just verify subfolders exist (team/subteam/ongoing/finished/deleted)
+                // URI points to TRECollect_logsheets, just verify subfolders exist (team/subteam/ongoing/finished/deleted)
                 // This won't recreate anything, just ensures the subfolders exist
                 if (!folderHelper.ensureSubfoldersExist(settingsPreferences)) {
                     android.util.Log.w("SettingsActivity", "Some subfolders could not be verified/created")

--- a/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/SettingsActivity.kt
@@ -353,7 +353,7 @@ class SettingsActivity : AppCompatActivity() {
         // Load and display logsheets status
         updateLogsheetsStatus()
 
-        // Version at end of scrollable content (e.g. "v1.2.3"); default "v0.0.0" for debug builds
+        // Version at end of scrollable content (e.g. "v1.2.3"); default "vdev" for debug builds
         val versionText = findViewById<TextView>(R.id.textVersion)
         versionText.text = getAppVersionString()
     }

--- a/app/src/main/java/com/trec/trecollect/ui/SiteDetailActivity.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/SiteDetailActivity.kt
@@ -1065,9 +1065,10 @@ class SiteDetailActivity : AppCompatActivity() {
                                                         // Update the add button state (canAdd for dynamic forms is always true)
                                                         lifecycleScope.launch {
                                                             withContext(Dispatchers.Main) {
-                                                                if (isDestroyed || isFinishing) return@withContext
-                                                                foundViewHolder.updateAddButtonState(baseForm) { f ->
-                                                                    f.id == baseForm.id && f.isDynamic
+                                                                if (!isDestroyed && !isFinishing) {
+                                                                    foundViewHolder.updateAddButtonState(baseForm) { f ->
+                                                                        f.id == baseForm.id && f.isDynamic
+                                                                    }
                                                                 }
                                                             }
                                                         }

--- a/app/src/main/java/com/trec/trecollect/ui/ZoomableImageView.kt
+++ b/app/src/main/java/com/trec/trecollect/ui/ZoomableImageView.kt
@@ -1,0 +1,138 @@
+package com.trec.trecollect.ui
+
+import android.content.Context
+import android.graphics.Matrix
+import android.graphics.RectF
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector
+import androidx.appcompat.widget.AppCompatImageView
+
+/**
+ * ImageView that supports pinch-to-zoom and panning.
+ * Image starts fit-center; user can zoom (1x–4x relative to fit) and pan when zoomed.
+ */
+class ZoomableImageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AppCompatImageView(context, attrs, defStyleAttr) {
+
+    private val matrix = Matrix()
+    private val viewRect = RectF()
+    private val drawableRect = RectF()
+
+    private var fitScale = 1f
+    private var currentScale = 1f
+    private val maxScaleFactor = 4f
+
+    private var lastTouchX = 0f
+    private var lastTouchY = 0f
+
+    private val scaleGestureDetector = ScaleGestureDetector(context, object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        override fun onScaleBegin(detector: ScaleGestureDetector): Boolean = true
+
+        override fun onScale(detector: ScaleGestureDetector): Boolean {
+            val scaleFactor = detector.scaleFactor
+            val newScale = (currentScale * scaleFactor).coerceIn(fitScale, fitScale * maxScaleFactor)
+            if (newScale != currentScale) {
+                val focusX = detector.focusX
+                val focusY = detector.focusY
+                matrix.postScale(newScale / currentScale, newScale / currentScale, focusX, focusY)
+                currentScale = newScale
+                constrainTranslation()
+                imageMatrix = matrix
+            }
+            return true
+        }
+    })
+
+    init {
+        scaleType = ScaleType.MATRIX
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w > 0 && h > 0) {
+            centerImage()
+        }
+    }
+
+    override fun setImageDrawable(drawable: Drawable?) {
+        super.setImageDrawable(drawable)
+        if (width > 0 && height > 0 && drawable != null) {
+            post { centerImage() }
+        }
+    }
+
+    override fun setImageBitmap(bm: android.graphics.Bitmap?) {
+        super.setImageBitmap(bm)
+        if (width > 0 && height > 0 && bm != null) {
+            post { centerImage() }
+        }
+    }
+
+    private fun centerImage() {
+        val drawable = drawable ?: return
+        val dWidth = drawable.intrinsicWidth.toFloat()
+        val dHeight = drawable.intrinsicHeight.toFloat()
+        val vWidth = width.toFloat()
+        val vHeight = height.toFloat()
+        if (dWidth <= 0 || dHeight <= 0 || vWidth <= 0 || vHeight <= 0) return
+
+        matrix.reset()
+        fitScale = (vWidth / dWidth).coerceAtMost(vHeight / dHeight)
+        currentScale = fitScale
+        matrix.setScale(fitScale, fitScale)
+        val dx = (vWidth - dWidth * fitScale) / 2f
+        val dy = (vHeight - dHeight * fitScale) / 2f
+        matrix.postTranslate(dx, dy)
+        imageMatrix = matrix
+    }
+
+    private fun constrainTranslation() {
+        val d = drawable ?: return
+        drawableRect.set(0f, 0f, d.intrinsicWidth.toFloat(), d.intrinsicHeight.toFloat())
+        matrix.mapRect(drawableRect)
+        viewRect.set(0f, 0f, width.toFloat(), height.toFloat())
+        var dx = 0f
+        var dy = 0f
+        if (drawableRect.width() <= viewRect.width()) {
+            dx = viewRect.centerX() - drawableRect.centerX()
+        } else {
+            if (drawableRect.left > viewRect.left) dx = viewRect.left - drawableRect.left
+            if (drawableRect.right < viewRect.right) dx = viewRect.right - drawableRect.right
+        }
+        if (drawableRect.height() <= viewRect.height()) {
+            dy = viewRect.centerY() - drawableRect.centerY()
+        } else {
+            if (drawableRect.top > viewRect.top) dy = viewRect.top - drawableRect.top
+            if (drawableRect.bottom < viewRect.bottom) dy = viewRect.bottom - drawableRect.bottom
+        }
+        matrix.postTranslate(dx, dy)
+        imageMatrix = matrix
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                lastTouchX = event.x
+                lastTouchY = event.y
+            }
+            MotionEvent.ACTION_MOVE -> {
+                if (!scaleGestureDetector.isInProgress) {
+                    val dx = event.x - lastTouchX
+                    val dy = event.y - lastTouchY
+                    matrix.postTranslate(dx, dy)
+                    constrainTranslation()
+                    imageMatrix = matrix
+                    lastTouchX = event.x
+                    lastTouchY = event.y
+                }
+            }
+        }
+        scaleGestureDetector.onTouchEvent(event)
+        return true
+    }
+}

--- a/app/src/main/res/drawable/ic_visibility.xml
+++ b/app/src/main/res/drawable/ic_visibility.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_photo_preview.xml
+++ b/app/src/main/res/layout/dialog_photo_preview.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#E6000000"
+    android:clickable="true"
+    android:focusable="true">
+
+    <com.trec.trecollect.ui.ZoomableImageView
+        android:id="@+id/imagePhoto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/view_photo" />
+
+    <ImageButton
+        android:id="@+id/buttonClosePreview"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="top|end"
+        android:layout_margin="16dp"
+        android:src="@android:drawable/ic_menu_close_clear_cancel"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/close"
+        android:scaleType="centerInside"
+        android:padding="12dp"
+        android:alpha="0.9" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/dialog_timepicker.xml
+++ b/app/src/main/res/layout/dialog_timepicker.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginBottom="24dp">
+
+        <NumberPicker
+            android:id="@+id/numberPickerHours"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:minHeight="100dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/timepicker_hours_label"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp" />
+
+        <NumberPicker
+            android:id="@+id/numberPickerMinutes"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:minHeight="100dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/timepicker_minutes_label"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp" />
+
+        <NumberPicker
+            android:id="@+id/numberPickerSeconds"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:minHeight="100dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/timepicker_seconds_label"
+            android:textSize="14sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonClear"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/clear"
+            android:layout_marginEnd="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonCancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/cancel"
+            android:layout_marginEnd="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonSave"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/timepicker_save" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/field_photo.xml
+++ b/app/src/main/res/layout/field_photo.xml
@@ -13,21 +13,76 @@
         android:textStyle="bold"
         android:layout_marginBottom="8dp" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/buttonCapture"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/take_photo"
-        android:icon="@android:drawable/ic_menu_camera" />
-
-    <TextView
-        android:id="@+id/textFileName"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonCapture"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/take_photo"
+            android:drawablePadding="4dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp"
+            android:layout_marginEnd="8dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonChooseFromGallery"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/choose_photo"
+            android:drawablePadding="4dp"
+            android:insetTop="0dp"
+            android:insetBottom="0dp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/photoInfoRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
         android:layout_marginTop="8dp"
-        android:textSize="12sp"
-        android:textColor="?android:attr/textColorSecondary"
-        android:visibility="gone" />
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/textFileName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+        <ImageButton
+            android:id="@+id/buttonViewPhoto"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="8dp"
+            android:src="@drawable/ic_visibility"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/view_photo"
+            android:scaleType="centerInside"
+            android:padding="8dp" />
+
+        <ImageButton
+            android:id="@+id/buttonClearPhoto"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="4dp"
+            android:src="@android:drawable/ic_menu_delete"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/clear_photo"
+            android:scaleType="centerInside"
+            android:padding="8dp" />
+
+    </LinearLayout>
 
 </LinearLayout>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,4 +183,11 @@
     <string name="download_progress_downloading">Downloading tiles… (%1$d)</string>
     <string name="region_downloaded_success">Region downloaded successfully</string>
     <string name="region_download_error">Error downloading region. Please check your internet connection.</string>
+
+    <!-- Timepicker dialog -->
+    <string name="timepicker_dialog_title">Set time (H:M:S)</string>
+    <string name="timepicker_hours_label">H</string>
+    <string name="timepicker_minutes_label">M</string>
+    <string name="timepicker_seconds_label">S</string>
+    <string name="timepicker_save">Save</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="use_map">Use map</string>
     <string name="display_image">Display image</string>
     <string name="take_photo">Take Photo</string>
+    <string name="choose_photo">Choose from gallery</string>
     <string name="no_selection">No selection</string>
     <string name="table">Table</string>
 
@@ -147,6 +148,11 @@
     <string name="error_label">Error: %1$s</string>
     <string name="label_required">%1$s *</string>
     <string name="photo_filename">Photo: %1$s</string>
+    <string name="photo_preview_content_description">Photo preview</string>
+    <string name="view_photo">View photo</string>
+    <string name="clear_photo">Clear photo</string>
+    <string name="close">Close</string>
+    <string name="photo_copy_error">Could not use selected image</string>
     <string name="instance_number">%1$s %2$d</string>
     <string name="no_logs_matching">No logs available matching \"%1$s\"</string>
     <string name="error_loading_path">Error loading path: %1$s</string>

--- a/app/src/test/java/com/trec/trecollect/data/FolderStructureHelperTest.kt
+++ b/app/src/test/java/com/trec/trecollect/data/FolderStructureHelperTest.kt
@@ -11,7 +11,7 @@ class FolderStructureHelperTest {
 
     @Test
     fun `folder name constants are defined correctly`() {
-        assertEquals("TREC_logsheets", FolderStructureHelper.PARENT_FOLDER_NAME)
+        assertEquals("TRECollect_logsheets", FolderStructureHelper.PARENT_FOLDER_NAME)
         assertEquals("ongoing", FolderStructureHelper.ONGOING_FOLDER)
         assertEquals("finished", FolderStructureHelper.FINISHED_FOLDER)
         assertEquals("deleted", FolderStructureHelper.DELETED_FOLDER)

--- a/app/src/test/java/com/trec/trecollect/data/FormConfigLoaderTest.kt
+++ b/app/src/test/java/com/trec/trecollect/data/FormConfigLoaderTest.kt
@@ -1609,7 +1609,7 @@ class FormConfigLoaderTest {
     }
 
     @Test
-    fun `parseJson parses default_value "now" for date field`() {
+    fun `parseJson parses default_value (now) for date field`() {
         val jsonString = """
         {
             "forms": [
@@ -1638,7 +1638,7 @@ class FormConfigLoaderTest {
     }
 
     @Test
-    fun `parseJson parses default_value "now" for time field`() {
+    fun `parseJson parses default_value (now) for time field`() {
         val jsonString = """
         {
             "forms": [
@@ -2012,7 +2012,7 @@ class FormConfigLoaderTest {
     }
 
     @Test
-    fun `parseJson parses default_value "true" for checkbox field`() {
+    fun `parseJson parses default_value (true) for checkbox field`() {
         val jsonString = """
         {
             "forms": [
@@ -2041,7 +2041,7 @@ class FormConfigLoaderTest {
     }
 
     @Test
-    fun `parseJson parses default_value "false" for checkbox field`() {
+    fun `parseJson parses default_value (false) for checkbox field`() {
         val jsonString = """
         {
             "forms": [

--- a/app/src/test/java/com/trec/trecollect/data/FormConfigLoaderTest.kt
+++ b/app/src/test/java/com/trec/trecollect/data/FormConfigLoaderTest.kt
@@ -136,6 +136,7 @@ class FormConfigLoaderTest {
                         {"id": "textarea", "label": "Textarea", "type": "textarea"},
                         {"id": "date", "label": "Date", "type": "date"},
                         {"id": "time", "label": "Time", "type": "time"},
+                        {"id": "timepicker", "label": "Timepicker", "type": "timepicker"},
                         {"id": "select", "label": "Select", "type": "select", "options": ["opt1"]},
                         {"id": "multiselect", "label": "Multiselect", "type": "multiselect", "options": ["opt1"]},
                         {"id": "select_image", "label": "Select Image", "type": "select_image", "options": [{"value": "opt1", "image": "images/opt1.png"}]},
@@ -158,23 +159,24 @@ class FormConfigLoaderTest {
 
         assertEquals(1, configs.size)
         val fields = configs[0].fields
-        assertEquals(16, fields.size)
+        assertEquals(17, fields.size)
         assertEquals(FormFieldConfig.FieldType.TEXT, fields[0].type)
         assertEquals(FormFieldConfig.FieldType.TEXTAREA, fields[1].type)
         assertEquals(FormFieldConfig.FieldType.DATE, fields[2].type)
         assertEquals(FormFieldConfig.FieldType.TIME, fields[3].type)
-        assertEquals(FormFieldConfig.FieldType.SELECT, fields[4].type)
-        assertEquals(FormFieldConfig.FieldType.MULTISELECT, fields[5].type)
-        assertEquals(FormFieldConfig.FieldType.SELECT_IMAGE, fields[6].type)
-        assertEquals(FormFieldConfig.FieldType.MULTISELECT_IMAGE, fields[7].type)
-        assertEquals(FormFieldConfig.FieldType.GPS, fields[8].type)
-        assertEquals(FormFieldConfig.FieldType.PHOTO, fields[9].type)
-        assertEquals(FormFieldConfig.FieldType.BARCODE, fields[10].type)
-        assertEquals(FormFieldConfig.FieldType.CHECKBOX, fields[11].type)
-        assertEquals(FormFieldConfig.FieldType.SECTION, fields[12].type)
-        assertEquals(FormFieldConfig.FieldType.IMAGE_DISPLAY, fields[13].type)
-        assertEquals(FormFieldConfig.FieldType.TABLE, fields[14].type)
-        assertEquals(FormFieldConfig.FieldType.DYNAMIC, fields[15].type)
+        assertEquals(FormFieldConfig.FieldType.TIMEPICKER, fields[4].type)
+        assertEquals(FormFieldConfig.FieldType.SELECT, fields[5].type)
+        assertEquals(FormFieldConfig.FieldType.MULTISELECT, fields[6].type)
+        assertEquals(FormFieldConfig.FieldType.SELECT_IMAGE, fields[7].type)
+        assertEquals(FormFieldConfig.FieldType.MULTISELECT_IMAGE, fields[8].type)
+        assertEquals(FormFieldConfig.FieldType.GPS, fields[9].type)
+        assertEquals(FormFieldConfig.FieldType.PHOTO, fields[10].type)
+        assertEquals(FormFieldConfig.FieldType.BARCODE, fields[11].type)
+        assertEquals(FormFieldConfig.FieldType.CHECKBOX, fields[12].type)
+        assertEquals(FormFieldConfig.FieldType.SECTION, fields[13].type)
+        assertEquals(FormFieldConfig.FieldType.IMAGE_DISPLAY, fields[14].type)
+        assertEquals(FormFieldConfig.FieldType.TABLE, fields[15].type)
+        assertEquals(FormFieldConfig.FieldType.DYNAMIC, fields[16].type)
     }
 
     @Test

--- a/app/src/test/java/com/trec/trecollect/data/SettingsPreferencesTest.kt
+++ b/app/src/test/java/com/trec/trecollect/data/SettingsPreferencesTest.kt
@@ -187,7 +187,8 @@ class SettingsPreferencesTest {
     @Test
     fun `getAppUuid returns dev-debug when dev build`() {
         whenever(mockSharedPreferences.getString("app_uuid", null)).thenReturn(null)
-        val result = settingsPreferences.getAppUuid()
+        val settingsPrefsDev = SettingsPreferences(mockContext, isDevBuildOverride = { true })
+        val result = settingsPrefsDev.getAppUuid()
         assertEquals("dev-debug", result)
         verify(mockEditor, never()).putString(eq("app_uuid"), any())
     }

--- a/app/src/test/java/com/trec/trecollect/data/SettingsPreferencesTest.kt
+++ b/app/src/test/java/com/trec/trecollect/data/SettingsPreferencesTest.kt
@@ -159,15 +159,13 @@ class SettingsPreferencesTest {
     fun `getAppUuid generates new UUID when not exists`() {
         whenever(mockSharedPreferences.getString("app_uuid", null)).thenReturn(null)
         whenever(mockEditor.putString(eq("app_uuid"), any())).thenReturn(mockEditor)
-        
-        val result = settingsPreferences.getAppUuid()
+        val settingsPrefsRelease = SettingsPreferences(mockContext, isDevBuildOverride = { false })
+        val result = settingsPrefsRelease.getAppUuid()
         
         assertNotNull(result)
         assertTrue(result.isNotEmpty())
-        // Should be a valid UUID format
         try {
             UUID.fromString(result)
-            // If we get here, it's a valid UUID
         } catch (e: IllegalArgumentException) {
             fail("Generated UUID is not valid: $result")
         }
@@ -179,10 +177,18 @@ class SettingsPreferencesTest {
     fun `getAppUuid returns existing UUID`() {
         val existingUuid = UUID.randomUUID().toString()
         whenever(mockSharedPreferences.getString("app_uuid", null)).thenReturn(existingUuid)
-        
-        val result = settingsPreferences.getAppUuid()
+        val settingsPrefsRelease = SettingsPreferences(mockContext, isDevBuildOverride = { false })
+        val result = settingsPrefsRelease.getAppUuid()
         
         assertEquals(existingUuid, result)
+        verify(mockEditor, never()).putString(eq("app_uuid"), any())
+    }
+
+    @Test
+    fun `getAppUuid returns dev-debug when dev build`() {
+        whenever(mockSharedPreferences.getString("app_uuid", null)).thenReturn(null)
+        val result = settingsPreferences.getAppUuid()
+        assertEquals("dev-debug", result)
         verify(mockEditor, never()).putString(eq("app_uuid"), any())
     }
 

--- a/app/src/test/java/com/trec/trecollect/ui/MainViewModelFactoryTest.kt
+++ b/app/src/test/java/com/trec/trecollect/ui/MainViewModelFactoryTest.kt
@@ -40,9 +40,7 @@ class MainViewModelFactoryTest {
     @Test
     fun `create returns MainViewModel for correct class`() {
         val viewModel = factory.create(MainViewModel::class.java)
-
         assertNotNull(viewModel)
-        assertTrue(viewModel is MainViewModel)
     }
 
     @Test
@@ -58,8 +56,8 @@ class MainViewModelFactoryTest {
     @Test
     fun `create handles ViewModel superclass`() {
         val viewModel = factory.create(MainViewModel::class.java)
-
-        assertTrue(viewModel is ViewModel)
+        val asViewModel: ViewModel = viewModel
+        assertNotNull(asViewModel)
     }
 
     // Helper test ViewModel class

--- a/app/src/test/java/com/trec/trecollect/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/trec/trecollect/ui/MainViewModelTest.kt
@@ -52,7 +52,6 @@ class MainViewModelTest {
         )
         val result = MainViewModel.CreateSiteResult.Success(site)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Success)
         assertEquals(site, result.site)
     }
 
@@ -61,7 +60,6 @@ class MainViewModelTest {
         val message = "Error message"
         val result = MainViewModel.CreateSiteResult.Error(message)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Error)
         assertEquals(message, result.message)
     }
 
@@ -69,7 +67,6 @@ class MainViewModelTest {
     fun `UploadSiteResult Success contains counts`() {
         val result = MainViewModel.UploadSiteResult.Success(5, 5)
 
-        assertTrue(result is MainViewModel.UploadSiteResult.Success)
         assertEquals(5, result.uploadedCount)
         assertEquals(5, result.totalCount)
     }
@@ -79,7 +76,6 @@ class MainViewModelTest {
         val message = "Upload failed"
         val result = MainViewModel.UploadSiteResult.Error(message)
 
-        assertTrue(result is MainViewModel.UploadSiteResult.Error)
         assertEquals(message, result.message)
     }
 
@@ -103,7 +99,6 @@ class MainViewModelTest {
     fun `CreateSiteResult Error with empty message`() {
         val result = MainViewModel.CreateSiteResult.Error("")
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Error)
         assertEquals("", result.message)
     }
     
@@ -112,7 +107,6 @@ class MainViewModelTest {
         val longMessage = "A".repeat(1000)
         val result = MainViewModel.CreateSiteResult.Error(longMessage)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Error)
         assertEquals(longMessage, result.message)
     }
     
@@ -120,7 +114,6 @@ class MainViewModelTest {
     fun `UploadSiteResult Success with zero counts`() {
         val result = MainViewModel.UploadSiteResult.Success(0, 0)
 
-        assertTrue(result is MainViewModel.UploadSiteResult.Success)
         assertEquals(0, result.uploadedCount)
         assertEquals(0, result.totalCount)
     }
@@ -130,7 +123,6 @@ class MainViewModelTest {
         // Edge case: uploadedCount > totalCount (shouldn't happen but test it)
         val result = MainViewModel.UploadSiteResult.Success(10, 5)
 
-        assertTrue(result is MainViewModel.UploadSiteResult.Success)
         assertEquals(10, result.uploadedCount)
         assertEquals(5, result.totalCount)
     }
@@ -140,7 +132,6 @@ class MainViewModelTest {
         // Note: message is not nullable, but test empty string
         val result = MainViewModel.UploadSiteResult.Error("")
 
-        assertTrue(result is MainViewModel.UploadSiteResult.Error)
         assertEquals("", result.message)
     }
     
@@ -153,7 +144,6 @@ class MainViewModelTest {
         )
         val result = MainViewModel.CreateSiteResult.Success(site)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Success)
         assertEquals(0L, result.site.id)
     }
     
@@ -166,7 +156,6 @@ class MainViewModelTest {
         )
         val result = MainViewModel.CreateSiteResult.Success(site)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Success)
         assertEquals(-1L, result.site.id)
     }
     
@@ -178,7 +167,6 @@ class MainViewModelTest {
         )
         val result = MainViewModel.CreateSiteResult.Success(site)
 
-        assertTrue(result is MainViewModel.CreateSiteResult.Success)
         assertEquals("", result.site.name)
     }
     


### PR DESCRIPTION
The persistency of UUID is solved by storing a file with the UUID in the local output folder. If it exists, it is used instead of generating a new one. Additionally, when running debug build (local testing and unit tests) `dev-debug` UUID is always used instead of generating random UUID (close #10).

New timepicker (spinner) widget was implemented to replace mask behaviour of the text field (close #35) and photo widget was extended to allow selecting existing photo instead of taking a new one and allowing preview of the selected photo (close #34).

Additionally some small bugs were fixed (close #36).